### PR TITLE
Add status phase to UPS CRD

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,2 +1,42 @@
 = UnifiedPush Operator
 
+== Development
+
+=== Prerequisites
+
+- Access to an OpenShift cluster with admin privileges to be able to create Roles.
+  https://github.com/minishift/minishift[Minishift] is suggested.
+
+- Go, Make, dep, operator-sdk, oc, kubectl (kubectl can just be a symlink to oc)
+
+=== Running the operator
+
+1. Prepare the operator project:
+
+```
+make cluster/prepare
+```
+
+2. Run the operator (locally, not in OpenShift):
+
+```
+make code/run
+```
+
+3. Create a UPS instance (in another terminal):
+
+```
+kubectl apply -f deploy/crds/aerogear_v1alpha1_unifiedpushserver_cr.yaml
+```
+
+4. Watch the status of your UPS instance provisioning (optional):
+
+```
+watch -n1 "oc get po && echo '' && oc get ups -o yaml"
+```
+
+5. When finished, clean up:
+
+```
+make cluster/clean
+```

--- a/pkg/apis/aerogear/v1alpha1/unifiedpushserver_types.go
+++ b/pkg/apis/aerogear/v1alpha1/unifiedpushserver_types.go
@@ -18,9 +18,7 @@ type UnifiedPushServerSpec struct {
 // UnifiedPushServerStatus defines the observed state of UnifiedPushServer
 // +k8s:openapi-gen=true
 type UnifiedPushServerStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	Phase StatusPhase `json:"phase"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -43,6 +41,14 @@ type UnifiedPushServerList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []UnifiedPushServer `json:"items"`
 }
+
+type StatusPhase string
+
+var (
+	PhaseEmpty     StatusPhase = ""
+	PhaseComplete  StatusPhase = "Complete"
+	PhaseProvision StatusPhase = "Provisioning"
+)
 
 func init() {
 	SchemeBuilder.Register(&UnifiedPushServer{}, &UnifiedPushServerList{})

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -138,6 +138,11 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, err
 	}
 
+	if instance.Status.Phase == aerogearv1alpha1.PhaseEmpty {
+		instance.Status.Phase = aerogearv1alpha1.PhaseProvision
+		r.client.Status().Update(context.TODO(), instance)
+	}
+
 	persistentVolumeClaim, err := newPostgresqlPersistentVolumeClaim(instance)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -317,6 +322,11 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, nil
 	} else if err != nil {
 		return reconcile.Result{}, err
+	}
+
+	if foundUnifiedpushDeployment.Status.ReadyReplicas > 0 && instance.Status.Phase != aerogearv1alpha1.PhaseComplete {
+		instance.Status.Phase = aerogearv1alpha1.PhaseComplete
+		r.client.Status().Update(context.TODO(), instance)
 	}
 
 	// Resources already exist - don't requeue


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9013

### Verification steps
1. Run the operator (see README changes here)
2. Watch the `status.phase` field. It should be "Provisioning" at the start, then eventually get to "Complete" (once the UPS pod is Ready):

```
watch oc get ups example-unifiedpushserver -o template={{.status.phase}}
```
