### PR TITLE
Handle UPS version updates

### DIFF
--- a/pkg/controller/unifiedpushserver/constants.go
+++ b/pkg/controller/unifiedpushserver/constants.go
@@ -1,0 +1,7 @@
+package unifiedpushserver
+
+const (
+	UPS_CONTAINER_NAME         = "ups"
+	OAUTH_PROXY_CONTAINER_NAME = "ups-oauth-proxy"
+	POSTGRES_CONTAINER_NAME    = "postgresql"
+)

--- a/pkg/controller/unifiedpushserver/postgresql.go
+++ b/pkg/controller/unifiedpushserver/postgresql.go
@@ -68,7 +68,7 @@ func newPostgresqlDeployment(cr *aerogearv1alpha1.UnifiedPushServer) (*appsv1.De
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:            "postgresql",
+							Name:            POSTGRES_CONTAINER_NAME,
 							Image:           postgresql.image(),
 							ImagePullPolicy: corev1.PullAlways,
 							Env: []corev1.EnvVar{
@@ -108,7 +108,7 @@ func newPostgresqlDeployment(cr *aerogearv1alpha1.UnifiedPushServer) (*appsv1.De
 							},
 							Ports: []corev1.ContainerPort{
 								{
-									Name:          "postgresql",
+									Name:          POSTGRES_CONTAINER_NAME,
 									Protocol:      corev1.ProtocolTCP,
 									ContainerPort: 5432,
 								},

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -93,7 +93,7 @@ func newUnifiedPushServerDeployment(cr *aerogearv1alpha1.UnifiedPushServer) (*ap
 					ServiceAccountName: cr.Name,
 					Containers: []corev1.Container{
 						{
-							Name:            "ups",
+							Name:            UPS_CONTAINER_NAME,
 							Image:           unifiedpush.image(),
 							ImagePullPolicy: corev1.PullAlways,
 							Env: []corev1.EnvVar{
@@ -141,7 +141,7 @@ func newUnifiedPushServerDeployment(cr *aerogearv1alpha1.UnifiedPushServer) (*ap
 							},
 							Ports: []corev1.ContainerPort{
 								{
-									Name:          "ups",
+									Name:          UPS_CONTAINER_NAME,
 									Protocol:      corev1.ProtocolTCP,
 									ContainerPort: 8080,
 								},
@@ -174,7 +174,7 @@ func newUnifiedPushServerDeployment(cr *aerogearv1alpha1.UnifiedPushServer) (*ap
 							},
 						},
 						{
-							Name:            "ups-oauth-proxy",
+							Name:            OAUTH_PROXY_CONTAINER_NAME,
 							Image:           proxy.image(),
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{

--- a/pkg/controller/unifiedpushserver/util.go
+++ b/pkg/controller/unifiedpushserver/util.go
@@ -2,6 +2,8 @@ package unifiedpushserver
 
 import (
 	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	"strings"
 
@@ -52,4 +54,30 @@ func generatePassword() (string, error) {
 		return "", errors.Wrap(err, "error generating password")
 	}
 	return strings.Replace(generatedPassword.String(), "-", "", -1), nil
+}
+
+func findContainerSpec(deployment *appsv1.Deployment, name string) *corev1.Container {
+	if deployment == nil || &deployment.Spec == nil || &deployment.Spec.Template == nil || &deployment.Spec.Template.Spec == nil || &deployment.Spec.Template.Spec.Containers == nil || len(deployment.Spec.Template.Spec.Containers) == 0 {
+		return nil
+	}
+
+	for _, spec := range deployment.Spec.Template.Spec.Containers {
+		if spec.Name == name {
+			return &spec
+		}
+	}
+
+	return nil
+}
+
+func updateContainerSpecImage(deployment *appsv1.Deployment, name string, image string) {
+	if deployment == nil || &deployment.Spec == nil || &deployment.Spec.Template == nil || &deployment.Spec.Template.Spec == nil || &deployment.Spec.Template.Spec.Containers == nil || len(deployment.Spec.Template.Spec.Containers) == 0 {
+		return
+	}
+
+	for idx, spec := range deployment.Spec.Template.Spec.Containers {
+		if spec.Name == name {
+			deployment.Spec.Template.Spec.Containers[idx].Image = image
+		}
+	}
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9012

Code is checking the image of container specs (**specs**! not actually checking the existing pods) in the deployment spec and if they are different than the desired image, it updates the deployment to use those images.
This kind of reconciliation code is borrowed from https://github.com/operator-framework/operator-sdk/blob/master/example/memcached-operator/memcached_controller.go.tmpl#L128

Verification:
* Prepare cluster: `make cluster/clean && make cluster/prepare`
* Run the operator: `make code/run`
* Deploy the sample unified push: `oc apply -f deploy/crds/aerogear_v1alpha1_unifiedpushserver_cr.yaml`
* Wait until everything is provisioned
* Edit 1 or more image in deployments (unifiedpush and its postgres)
* You will see that the operator will update the images back
