### PR TITLE
Add ServiceMonitor definition for Prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,12 @@ test/unit:
 
 .PHONY: cluster/prepare
 cluster/prepare:
-	-oc new-project $(NAMESPACE)
-	-kubectl create -f deploy/service_account.yaml
-	-kubectl create -f deploy/role.yaml
-	-kubectl create -f deploy/role_binding.yaml
-	-kubectl create -f deploy/crds/aerogear_v1alpha1_unifiedpushserver_crd.yaml
+	-kubectl create namespace $(NAMESPACE)
+	-kubectl label namespace $(NAMESPACE) monitoring-key=middleware
+	-kubectl create -n $(NAMESPACE) -f deploy/service_account.yaml
+	-kubectl create -n $(NAMESPACE) -f deploy/role.yaml
+	-kubectl create -n $(NAMESPACE) -f deploy/role_binding.yaml
+	-kubectl create -n $(NAMESPACE) -f deploy/crds/aerogear_v1alpha1_unifiedpushserver_crd.yaml
 
 .PHONY: cluster/clean
 cluster/clean:

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,18 @@
 = UnifiedPush Operator
 
+== Metrics
+
+The application-monitoring stack provisioned by the
+https://github.com/integr8ly/application-monitoring-operator[application-monitoring-operator]
+can be used to gather metrics from the operator here.  Once you have
+provisioned that (or the ServiceMonitor CRD at a minimum), you can run
+the following commands to configure it:
+
+```
+kubectl label namespace unifiedpush monitoring-key=middleware
+kubectl create -n unifiedpush -f deploy/service_monitor.yaml
+```
+
 == Development
 
 === Prerequisites
@@ -7,7 +20,7 @@
 - Access to an OpenShift cluster with admin privileges to be able to create Roles.
   https://github.com/minishift/minishift[Minishift] is suggested.
 
-- Go, Make, dep, operator-sdk, oc, kubectl (kubectl can just be a symlink to oc)
+- Go, Make, dep, operator-sdk, kubectl (kubectl can just be a symlink to oc)
 
 === Running the operator
 
@@ -32,7 +45,7 @@ kubectl apply -f deploy/crds/aerogear_v1alpha1_unifiedpushserver_cr.yaml
 4. Watch the status of your UPS instance provisioning (optional):
 
 ```
-watch -n1 "oc get po && echo '' && oc get ups -o yaml"
+watch -n1 "kubectl get po && echo '' && kubectl get ups -o yaml"
 ```
 
 5. When finished, clean up:

--- a/deploy/service_monitor.yaml
+++ b/deploy/service_monitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    monitoring-key: middleware
+  name: unifiedpush-operator
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+  selector:
+    matchLabels:
+      name: unifiedpush-operator


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9011

Running `make cluster/prepare` will now label the namespace with
`monitoring_key=middleware`, which the prometheus-operator provisioned
by the application-monitoring-operator[1] will look out for.

The prometheus-operator can read the ServiceMonitor CR, and instruct
the Prometheus instance to start scraping metrics as appropriate.

This change doesn't create any GrafanaDashboard or PrometheusRule
CRs. Since we're just exposing the default metrics from an operator,
it should be up to the SRE team to decide what they want to be able to
see and be alerted by, and they would likely want this to be the same
for all operators, rather than what _we_ decide.

[1] https://github.com/integr8ly/application-monitoring-operator