### PR TITLE
Create Push apps and variants in UPS based on equivalent CRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ cluster/prepare:
 	-kubectl create -n $(NAMESPACE) -f deploy/service_account.yaml
 	-kubectl create -n $(NAMESPACE) -f deploy/role.yaml
 	-kubectl create -n $(NAMESPACE) -f deploy/role_binding.yaml
-	-kubectl apply -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
-	-kubectl apply -f deploy/crds/push_v1alpha1_pushapplication_crd.yaml
-	-kubectl apply -f deploy/crds/push_v1alpha1_androidvariant_crd.yaml
-	-kubectl apply -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
+	-kubectl apply -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
+	-kubectl apply -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_pushapplication_crd.yaml
+	-kubectl apply -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_androidvariant_crd.yaml
+	-kubectl apply -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
 
 .PHONY: cluster/clean
 cluster/clean:
@@ -55,4 +55,7 @@ cluster/clean:
 	-kubectl delete -n $(NAMESPACE) -f deploy/role_binding.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/service_account.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
+	-kubectl delete -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_pushapplication_crd.yaml
+	-kubectl delete -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_androidvariant_crd.yaml
+	-kubectl delete -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
 	-kubectl delete namespace $(NAMESPACE)

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ cluster/prepare:
 	-kubectl create -n $(NAMESPACE) -f deploy/role.yaml
 	-kubectl create -n $(NAMESPACE) -f deploy/role_binding.yaml
 	-kubectl apply -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
+	-kubectl apply -f deploy/crds/push_v1alpha1_pushapplication_crd.yaml
+	-kubectl apply -f deploy/crds/push_v1alpha1_androidvariant_crd.yaml
+	-kubectl apply -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
 
 .PHONY: cluster/clean
 cluster/clean:

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ cluster/prepare:
 
 .PHONY: cluster/clean
 cluster/clean:
+	-kubectl delete -n $(NAMESPACE) iosVariant --all
+	-kubectl delete -n $(NAMESPACE) androidVariant --all
+	-kubectl delete -n $(NAMESPACE) pushApplication --all
+	-kubectl delete -n $(NAMESPACE) unifiedpushServer --all
 	-kubectl delete -f deploy/role.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/role_binding.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/service_account.yaml

--- a/README.adoc
+++ b/README.adoc
@@ -41,6 +41,9 @@ kubectl create -n unifiedpush -f deploy/service_account.yaml
 kubectl create -n unifiedpush -f deploy/role.yaml
 kubectl create -n unifiedpush -f deploy/role_binding.yaml
 kubectl create -n unifiedpush -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
+kubectl create -n unifiedpush -f deploy/crds/push_v1alpha1_pushapplication_crd.yaml
+kubectl create -n unifiedpush -f deploy/crds/push_v1alpha1_androidvariant_crd.yaml
+kubectl create -n unifiedpush -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
 kubectl create -n unifiedpush -f deploy/operator.yaml
 ....
 
@@ -81,6 +84,165 @@ to configure it:
 ....
 kubectl label namespace unifiedpush monitoring-key=middleware
 kubectl create -n unifiedpush -f deploy/service_monitor.yaml
+....
+
+== Custom Resources (aka How to get value from this operator)
+
+=== UnifiedPushServer
+
+This is the main installation resource kind. Creation of a valid
+UnifiedPushServer CR will result in a functional AeroGear
+UnifiedPushServer deployed to your namespace.
+
+[NOTE]
+====
+This operator currently only supports one UnifiedPushServer CR to be
+created.
+====
+
+There are currently no configurable fields in the UnifiedPushServer CR
+apart from the name, so the example in
+`./deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml` is a good
+template:
+
+.push_v1alpha1_unifiedpushserver_cr.yaml
+[source,yaml]
+----
+apiVersion: push.aerogear.org/v1alpha1
+kind: UnifiedPushServer
+metadata:
+  name: example-unifiedpushserver
+----
+
+To create this, you can run:
+
+....
+kubectl apply -n unifiedpush -f ./deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml
+....
+
+To see the created instance then, you can run:
+
+....
+kubectl get ups example-unifiedpushserver -n unifiedpush -o yaml
+....
+
+=== PushApplication
+
+Once you've got your `UnifiedPushServer` up and running, you can
+create a `PushApplication`.
+
+The only configurable fields in a `PushApplication` are the name and
+description, like the example in
+`./deploy/crds/push_v1alpha1_pushapplication_cr.yaml`:
+
+.push_v1alpha1_pushapplication_cr.yaml
+[source,yaml]
+----
+apiVersion: push.aerogear.org/v1alpha1
+kind: PushApplication
+metadata:
+  name: example-pushapplication
+spec:
+  description: 'An example push application to demonstrate the
+    unifiedpush-operator'
+----
+
+To create this, you can run:
+
+....
+kubectl apply -n unifiedpush -f ./deploy/crds/push_v1alpha1_pushapplication_cr.yaml
+....
+
+To see the created instance then, you can run:
+
+....
+kubectl get pushApplication example-pushapplication -n unifiedpush -o yaml
+....
+
+Shortly after it's created, you should be able to see it in the list
+of Applications in the UnifiedPush Admin UI, and you should also be
+able to see the `pushApplicationId` and `masterSecret` fields on the
+`status` object of your PushApplication instance in Kubernetes.
+
+=== AndroidVariant
+
+After creating the PushApplication above, you should be able to get
+the `pushApplicationId` from the status, this will be needed to be
+able to create Variants:
+
+....
+kubectl get PushApplication example-pushapplication -n unifiedpush -o jsonpath='{.status.pushApplicationId}'
+....
+
+Here are all of the configurable fields in an AndroidVariant:
+
+.AndroidVariant fields
+|===
+|Field Name |Description
+
+|pushApplicationId
+|ID of the PushApplication that this variant corresponds to
+
+|description
+|Human friendly description for the variant
+
+|senderId
+|The "Google Project Number from the API Console
+
+|serverKey
+|The key from the Firebase Console of a project which has been enabled for FCM
+|===
+
+There's an example at
+`./deploy/crds/push_v1alpha1_androidvariant_cr.yaml` that can be
+modified and created as follows:
+
+....
+kubectl apply -n unifiedpush -f ./deploy/crds/push_v1alpha1_androidvariant_cr.yaml
+....
+
+=== IOSVariant
+
+After creating the PushApplication above, you should be able to get
+the `pushApplicationId` from the status, this will be needed to be
+able to create Variants:
+
+....
+kubectl get PushApplication example-pushapplication -n unifiedpush -o jsonpath='{.status.pushApplicationId}'
+....
+
+Here are all of the configurable fields in an AndroidVariant:
+
+.IOSVariant fields
+|===
+|Field Name |Description
+
+|pushApplicationId
+|ID of the PushApplication that this variant corresponds to
+
+|description
+|Human friendly description for the variant
+
+|certificate
+|The base64 encoded APNs certificate that is needed to establish a
+ connection to Apple's APNs Push Servers
+
+|passphrase
+|The APNs passphrase that is needed to establish a connection to
+ Apple's APNs Push Servers
+
+|production
+|If `true`, indicates that a connection to production APNs server should
+ be used. If `false` a connection to the Sandbox/Development APNs server
+ will be used.
+|===
+
+There's an example at
+`./deploy/crds/push_v1alpha1_iosvariant_cr.yaml` that can be
+modified and created as follows:
+
+....
+kubectl apply -n unifiedpush -f ./deploy/crds/push_v1alpha1_iosvariant_cr.yaml
 ....
 
 == Getting help

--- a/README.adoc
+++ b/README.adoc
@@ -152,7 +152,24 @@ kubectl apply -f deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml -n unifiedp
 watch -n1 "kubectl get po -n unifiedpush && echo '' && kubectl get ups -o yaml -n unifiedpush"
 ....
 
-5. When finished, clean up:
+5. If you want to be able to work with resources that require the
+local instance of your operator to be able to talk to the UPS instance
+in the cluster, then you'll need to make a corresponding domain name
+available locally. Something like the following should work, by adding
+an entry to /etc/hosts for the example Service that's created, then
+forwarding the port from the relevant Pod in the cluster to the local
+machine. Run this in a separate terminal, and ctrl+c to clean it up
+when finished:
+
+// TODO: We could maybe use a non-privileged port instead of :80?
+....
+# su/sudo is needed to be able to:
+# - modify /etc/hosts
+# - bind to port :80
+KUBECONFIG=$HOME/.kube/config su -c "echo '127.0.0.1   example-unifiedpushserver-unifiedpush' >> /etc/hosts && kubectl port-forward $(kubectl get po -l service=ups -o name) 80:8080 && sed -i -e 's/^127.0.0.1   example-unifiedpushserver-unifiedpush$//g' -e '/^[[:space:]]*$/d' /etc/hosts"
+....
+
+6. When finished, clean up:
 
 ....
 make cluster/clean

--- a/README.adoc
+++ b/README.adoc
@@ -211,7 +211,7 @@ able to create Variants:
 kubectl get PushApplication example-pushapplication -n unifiedpush -o jsonpath='{.status.pushApplicationId}'
 ....
 
-Here are all of the configurable fields in an AndroidVariant:
+Here are all of the configurable fields in an IOSVariant:
 
 .IOSVariant fields
 |===

--- a/deploy/crds/push_v1alpha1_androidvariant_cr.yaml
+++ b/deploy/crds/push_v1alpha1_androidvariant_cr.yaml
@@ -6,3 +6,4 @@ spec:
   description: 'My super Android variant'
   serverKey: 'somekeyinbase64=='
   senderId: '123456'
+  pushApplicationId: '123456'

--- a/deploy/crds/push_v1alpha1_iosvariant_cr.yaml
+++ b/deploy/crds/push_v1alpha1_iosvariant_cr.yaml
@@ -7,3 +7,4 @@ spec:
   certificate: 'somekeyinbase64=='
   passphrase: '123456'
   production: false
+  pushApplicationId: '123456'

--- a/pkg/controller/add_androidvariant.go
+++ b/pkg/controller/add_androidvariant.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/aerogear/unifiedpush-operator/pkg/controller/androidvariant"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, androidvariant.Add)
+}

--- a/pkg/controller/add_iosvariant.go
+++ b/pkg/controller/add_iosvariant.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/aerogear/unifiedpush-operator/pkg/controller/iosvariant"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, iosvariant.Add)
+}

--- a/pkg/controller/add_pushapplication.go
+++ b/pkg/controller/add_pushapplication.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/aerogear/unifiedpush-operator/pkg/controller/pushapplication"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, pushapplication.Add)
+}

--- a/pkg/controller/androidvariant/androidvariant_controller.go
+++ b/pkg/controller/androidvariant/androidvariant_controller.go
@@ -1,0 +1,153 @@
+package androidvariant
+
+import (
+	"context"
+
+	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_androidvariant")
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new AndroidVariant Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileAndroidVariant{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("androidvariant-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource AndroidVariant
+	err = c.Watch(&source.Kind{Type: &pushv1alpha1.AndroidVariant{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// TODO(user): Modify this to be the types you create that are owned by the primary resource
+	// Watch for changes to secondary resource Pods and requeue the owner AndroidVariant
+	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &pushv1alpha1.AndroidVariant{},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileAndroidVariant{}
+
+// ReconcileAndroidVariant reconciles a AndroidVariant object
+type ReconcileAndroidVariant struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a AndroidVariant object and makes changes based on the state read
+// and what is in the AndroidVariant.Spec
+// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
+// a Pod as an example
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileAndroidVariant) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling AndroidVariant")
+
+	// Fetch the AndroidVariant instance
+	instance := &pushv1alpha1.AndroidVariant{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Define a new Pod object
+	pod := newPodForCR(instance)
+
+	// Set AndroidVariant instance as the owner and controller
+	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Check if this Pod already exists
+	found := &corev1.Pod{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		err = r.client.Create(context.TODO(), pod)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Pod created successfully - don't requeue
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Pod already exists - don't requeue
+	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
+	return reconcile.Result{}, nil
+}
+
+// newPodForCR returns a busybox pod with the same name/namespace as the cr
+func newPodForCR(cr *pushv1alpha1.AndroidVariant) *corev1.Pod {
+	labels := map[string]string{
+		"app": cr.Name,
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-pod",
+			Namespace: cr.Namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "busybox",
+					Image:   "busybox",
+					Command: []string{"sleep", "3600"},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/androidvariant/androidvariant_controller.go
+++ b/pkg/controller/androidvariant/androidvariant_controller.go
@@ -129,6 +129,7 @@ func (r *ReconcileAndroidVariant) Reconcile(request reconcile.Request) (reconcil
 	}
 
 	instance.Status.VariantId = variantId
+	instance.Status.Ready = true
 	err = r.client.Status().Update(context.TODO(), instance)
 	if err != nil {
 		reqLogger.Error(err, "Error updating AndroidVariant status", "AndroidVariant.Name", instance.Name)

--- a/pkg/controller/androidvariant/androidvariant_controller.go
+++ b/pkg/controller/androidvariant/androidvariant_controller.go
@@ -2,17 +2,15 @@ package androidvariant
 
 import (
 	"context"
+	"time"
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
+	"github.com/aerogear/unifiedpush-operator/pkg/controller/util"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -21,11 +19,6 @@ import (
 )
 
 var log = logf.Log.WithName("controller_androidvariant")
-
-/**
-* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
-* business logic.  Delete these comments after modifying this file.*
- */
 
 // Add creates a new AndroidVariant Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -52,16 +45,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// TODO(user): Modify this to be the types you create that are owned by the primary resource
-	// Watch for changes to secondary resource Pods and requeue the owner AndroidVariant
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &pushv1alpha1.AndroidVariant{},
-	})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -75,13 +58,13 @@ type ReconcileAndroidVariant struct {
 	scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the cluster for a AndroidVariant object and makes changes based on the state read
-// and what is in the AndroidVariant.Spec
-// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
-// a Pod as an example
+// Reconcile reads that state of the cluster for a AndroidVariant
+// object and makes changes based on the state read and what is in the
+// AndroidVariant.Spec
 // Note:
-// The Controller will requeue the Request to be processed again if the returned error is non-nil or
-// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+// The Controller will requeue the Request to be processed again if
+// the returned error is non-nil or Result.Requeue is true, otherwise
+// upon completion it will remove the work from the queue.
 func (r *ReconcileAndroidVariant) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling AndroidVariant")
@@ -100,54 +83,62 @@ func (r *ReconcileAndroidVariant) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	// Define a new Pod object
-	pod := newPodForCR(instance)
-
-	// Set AndroidVariant instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
-		return reconcile.Result{}, err
+	// Get a UPS Client for interactions with the UPS service
+	unifiedpushClient, err := util.UnifiedpushClient(r.client, reqLogger)
+	if err != nil {
+		reqLogger.Error(err, "Error getting a UPS Client.", "AndroidVariant.Name", instance.Name)
+		return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
-	// Check if this Pod already exists
-	found := &corev1.Pod{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
-	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
-		err = r.client.Create(context.TODO(), pod)
+	// Check if the CR was marked to be deleted
+	if instance.GetDeletionTimestamp() != nil {
+		// First delete from UPS
+		err := unifiedpushClient.DeleteAndroidVariant(instance)
 		if err != nil {
+			reqLogger.Error(err, "Failed to delete AndroidVariant from UPS", "AndroidVaraint.Name", instance.Name)
 			return reconcile.Result{}, err
 		}
 
-		// Pod created successfully - don't requeue
+		// Then unset finalizers
+		instance.SetFinalizers(nil)
+		err = r.client.Update(context.TODO(), instance)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		return reconcile.Result{}, nil
-	} else if err != nil {
+	}
+
+	foundVariant, err := unifiedpushClient.GetAndroidVariant(instance)
+	if err != nil {
+		// this doesn't denote a 404. it is a 500
+		reqLogger.Error(err, "Error getting the existing Android variant.", "AndroidVariant.Name", instance.Name)
 		return reconcile.Result{}, err
 	}
 
-	// Pod already exists - don't requeue
-	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
-	return reconcile.Result{}, nil
-}
+	if foundVariant != "" {
+		// we don't do a full reconciliation (update push app on UPS server based on CR content) but we
+		// only do initial creation of push apps.
+		reqLogger.Info("Skip reconcile: Android Variant already exists in UPS", "AndroidVaraint.Name", instance.Name)
+		return reconcile.Result{}, nil
+	}
 
-// newPodForCR returns a busybox pod with the same name/namespace as the cr
-func newPodForCR(cr *pushv1alpha1.AndroidVariant) *corev1.Pod {
-	labels := map[string]string{
-		"app": cr.Name,
+	variantId, err := unifiedpushClient.CreateAndroidVariant(instance)
+	if err != nil {
+		reqLogger.Error(err, "Error creating Android variant in UPS.", "AndroidVaraint.Name", instance.Name)
+		return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 	}
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-pod",
-			Namespace: cr.Namespace,
-			Labels:    labels,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:    "busybox",
-					Image:   "busybox",
-					Command: []string{"sleep", "3600"},
-				},
-			},
-		},
+
+	instance.Status.VariantId = variantId
+	err = r.client.Status().Update(context.TODO(), instance)
+	if err != nil {
+		reqLogger.Error(err, "Error updating AndroidVariant status", "AndroidVariant.Name", instance.Name)
+		return reconcile.Result{}, err
 	}
+
+	if err := util.AddFinalizer(r.client, reqLogger, instance); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	reqLogger.Info("Android Variant created", "AndroidVariant.Name", instance.Name)
+	return reconcile.Result{}, nil
 }

--- a/pkg/controller/iosvariant/iosvariant_controller.go
+++ b/pkg/controller/iosvariant/iosvariant_controller.go
@@ -131,6 +131,7 @@ func (r *ReconcileIOSVariant) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	instance.Status.VariantId = variantId
+	instance.Status.Ready = true
 	err = r.client.Status().Update(context.TODO(), instance)
 	if err != nil {
 		reqLogger.Error(err, "Error updating IOSVariant status", "IOSVariant.Name", instance.Name)

--- a/pkg/controller/iosvariant/iosvariant_controller.go
+++ b/pkg/controller/iosvariant/iosvariant_controller.go
@@ -2,17 +2,17 @@ package iosvariant
 
 import (
 	"context"
+	"time"
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
+	"github.com/aerogear/unifiedpush-operator/pkg/controller/util"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -21,11 +21,6 @@ import (
 )
 
 var log = logf.Log.WithName("controller_iosvariant")
-
-/**
-* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
-* business logic.  Delete these comments after modifying this file.*
- */
 
 // Add creates a new IOSVariant Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -52,16 +47,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// TODO(user): Modify this to be the types you create that are owned by the primary resource
-	// Watch for changes to secondary resource Pods and requeue the owner IOSVariant
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &pushv1alpha1.IOSVariant{},
-	})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -75,13 +60,13 @@ type ReconcileIOSVariant struct {
 	scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the cluster for a IOSVariant object and makes changes based on the state read
-// and what is in the IOSVariant.Spec
-// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
-// a Pod as an example
+// Reconcile reads that state of the cluster for a IOSVariant object
+// and makes changes based on the state read and what is in the
+// IOSVariant.Spec
 // Note:
-// The Controller will requeue the Request to be processed again if the returned error is non-nil or
-// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+// The Controller will requeue the Request to be processed again if
+// the returned error is non-nil or Result.Requeue is true, otherwise
+// upon completion it will remove the work from the queue.
 func (r *ReconcileIOSVariant) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling IOSVariant")
@@ -100,32 +85,63 @@ func (r *ReconcileIOSVariant) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	// Define a new Pod object
-	pod := newPodForCR(instance)
-
-	// Set IOSVariant instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
-		return reconcile.Result{}, err
+	// Get a UPS Client for interactions with the UPS service
+	unifiedpushClient, err := util.UnifiedpushClient(r.client, reqLogger)
+	if err != nil {
+		reqLogger.Error(err, "Error getting a UPS Client.", "IOSVariant.Name", instance.Name)
+		return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
-	// Check if this Pod already exists
-	found := &corev1.Pod{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
-	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
-		err = r.client.Create(context.TODO(), pod)
+	// Check if the CR was marked to be deleted
+	if instance.GetDeletionTimestamp() != nil {
+		// First delete from UPS
+		err := unifiedpushClient.DeleteIOSVariant(instance)
 		if err != nil {
+			reqLogger.Error(err, "Failed to delete IOSVariant from UPS", "IOSVaraint.Name", instance.Name)
 			return reconcile.Result{}, err
 		}
 
-		// Pod created successfully - don't requeue
+		// Then unset finalizers
+		instance.SetFinalizers(nil)
+		err = r.client.Update(context.TODO(), instance)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		return reconcile.Result{}, nil
-	} else if err != nil {
+	}
+
+	foundVariant, err := unifiedpushClient.GetIOSVariant(instance)
+	if err != nil {
+		// this doesn't denote a 404. it is a 500
+		reqLogger.Error(err, "Error getting the existing iOS variant.", "IOSVariant.Name", instance.Name)
 		return reconcile.Result{}, err
 	}
 
-	// Pod already exists - don't requeue
-	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
+	if foundVariant != "" {
+		// we don't do a full reconciliation (update push app on UPS server based on CR content) but we
+		// only do initial creation of push apps.
+		reqLogger.Info("Skip reconcile: IOS Variant already exists in UPS", "IOSVaraint.Name", instance.Name)
+		return reconcile.Result{}, nil
+	}
+
+	variantId, err := unifiedpushClient.CreateIOSVariant(instance)
+	if err != nil {
+		reqLogger.Error(err, "Error creating iOS variant in UPS.", "IOSVaraint.Name", instance.Name)
+		return reconcile.Result{RequeueAfter: time.Second * 5}, nil
+	}
+
+	instance.Status.VariantId = variantId
+	err = r.client.Status().Update(context.TODO(), instance)
+	if err != nil {
+		reqLogger.Error(err, "Error updating IOSVariant status", "IOSVariant.Name", instance.Name)
+		return reconcile.Result{}, err
+	}
+
+	if err := util.AddFinalizer(r.client, reqLogger, instance); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	reqLogger.Info("IOS Variant created", "IOSVariant.Name", instance.Name)
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/iosvariant/iosvariant_controller.go
+++ b/pkg/controller/iosvariant/iosvariant_controller.go
@@ -1,0 +1,153 @@
+package iosvariant
+
+import (
+	"context"
+
+	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_iosvariant")
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new IOSVariant Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileIOSVariant{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("iosvariant-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource IOSVariant
+	err = c.Watch(&source.Kind{Type: &pushv1alpha1.IOSVariant{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// TODO(user): Modify this to be the types you create that are owned by the primary resource
+	// Watch for changes to secondary resource Pods and requeue the owner IOSVariant
+	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &pushv1alpha1.IOSVariant{},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileIOSVariant{}
+
+// ReconcileIOSVariant reconciles a IOSVariant object
+type ReconcileIOSVariant struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a IOSVariant object and makes changes based on the state read
+// and what is in the IOSVariant.Spec
+// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
+// a Pod as an example
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileIOSVariant) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling IOSVariant")
+
+	// Fetch the IOSVariant instance
+	instance := &pushv1alpha1.IOSVariant{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Define a new Pod object
+	pod := newPodForCR(instance)
+
+	// Set IOSVariant instance as the owner and controller
+	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Check if this Pod already exists
+	found := &corev1.Pod{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		err = r.client.Create(context.TODO(), pod)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Pod created successfully - don't requeue
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Pod already exists - don't requeue
+	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
+	return reconcile.Result{}, nil
+}
+
+// newPodForCR returns a busybox pod with the same name/namespace as the cr
+func newPodForCR(cr *pushv1alpha1.IOSVariant) *corev1.Pod {
+	labels := map[string]string{
+		"app": cr.Name,
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-pod",
+			Namespace: cr.Namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "busybox",
+					Image:   "busybox",
+					Command: []string{"sleep", "3600"},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/pushapplication/pushapplication_controller.go
+++ b/pkg/controller/pushapplication/pushapplication_controller.go
@@ -20,11 +20,6 @@ import (
 
 var log = logf.Log.WithName("controller_pushapplication")
 
-/**
-* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
-* business logic.  Delete these comments after modifying this file.*
- */
-
 // Add creates a new PushApplication Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -86,6 +81,7 @@ func (r *ReconcilePushApplication) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, err
 	}
 
+	// Get a UPS Client for interactions with the UPS service
 	unifiedpushClient, err := util.UnifiedpushClient(r.client, reqLogger)
 	if err != nil {
 		reqLogger.Error(err, "Error getting a UPS Client.", "PushApp.Name", instance.Name)
@@ -111,7 +107,6 @@ func (r *ReconcilePushApplication) Reconcile(request reconcile.Request) (reconci
 	}
 
 	foundApp, err := unifiedpushClient.GetApplication(instance)
-
 	if err != nil {
 		// this doesn't denote a 404. it is a 500
 		reqLogger.Error(err, "Error getting the existing push application.", "PushApp.Name", instance.Name)

--- a/pkg/controller/pushapplication/pushapplication_controller.go
+++ b/pkg/controller/pushapplication/pushapplication_controller.go
@@ -86,6 +86,8 @@ func (r *ReconcilePushApplication) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, err
 	}
 
+	// TODO: check if we're actually supposed to be deleting here instead of creating...
+
 	unifiedpushClient, err := util.UnifiedpushClient(r.client, reqLogger)
 	if err != nil {
 		reqLogger.Error(err, "Error getting a UPS Client.", "PushApp.Name", instance.Name)
@@ -110,6 +112,10 @@ func (r *ReconcilePushApplication) Reconcile(request reconcile.Request) (reconci
 	appId, secret, err := unifiedpushClient.CreateApplication(instance)
 	if err != nil {
 		reqLogger.Error(err, "Error creating push application.", "PushApp.Name", instance.Name)
+		return reconcile.Result{RequeueAfter: time.Second * 5}, nil
+	}
+
+	if err := util.AddFinalizer(r.client, reqLogger, instance); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/pushapplication/pushapplication_controller.go
+++ b/pkg/controller/pushapplication/pushapplication_controller.go
@@ -1,0 +1,153 @@
+package pushapplication
+
+import (
+	"context"
+
+	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_pushapplication")
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new PushApplication Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcilePushApplication{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("pushapplication-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource PushApplication
+	err = c.Watch(&source.Kind{Type: &pushv1alpha1.PushApplication{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// TODO(user): Modify this to be the types you create that are owned by the primary resource
+	// Watch for changes to secondary resource Pods and requeue the owner PushApplication
+	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &pushv1alpha1.PushApplication{},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcilePushApplication{}
+
+// ReconcilePushApplication reconciles a PushApplication object
+type ReconcilePushApplication struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a PushApplication object and makes changes based on the state read
+// and what is in the PushApplication.Spec
+// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
+// a Pod as an example
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcilePushApplication) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling PushApplication")
+
+	// Fetch the PushApplication instance
+	instance := &pushv1alpha1.PushApplication{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Define a new Pod object
+	pod := newPodForCR(instance)
+
+	// Set PushApplication instance as the owner and controller
+	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Check if this Pod already exists
+	found := &corev1.Pod{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		err = r.client.Create(context.TODO(), pod)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Pod created successfully - don't requeue
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Pod already exists - don't requeue
+	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
+	return reconcile.Result{}, nil
+}
+
+// newPodForCR returns a busybox pod with the same name/namespace as the cr
+func newPodForCR(cr *pushv1alpha1.PushApplication) *corev1.Pod {
+	labels := map[string]string{
+		"app": cr.Name,
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-pod",
+			Namespace: cr.Namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "busybox",
+					Image:   "busybox",
+					Command: []string{"sleep", "3600"},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -225,11 +225,15 @@ func newUnifiedPushServerService(cr *pushv1alpha1.UnifiedPushServer) (*corev1.Se
 		"org.aerogear.metrics/plain_endpoint": "/rest/prometheus/metrics",
 	}
 	serviceObjectMeta.Labels["mobile"] = "enabled"
+	serviceObjectMeta.Labels["internal"] = "unifiedpush"
 
 	return &corev1.Service{
 		ObjectMeta: serviceObjectMeta,
 		Spec: corev1.ServiceSpec{
-			Selector: labels(cr, "unifiedpush"),
+			Selector: map[string]string{
+				"app":     cr.Name,
+				"service": "ups",
+			},
 			Ports: []corev1.ServicePort{
 				corev1.ServicePort{
 					Name:     "web",

--- a/pkg/controller/util/add_finalizer.go
+++ b/pkg/controller/util/add_finalizer.go
@@ -13,6 +13,8 @@ import (
 // AddFinalizer will add a finalizer to the PushApplication CR so that
 // we can delete from UPS appropriately
 func AddFinalizer(client client.Client, reqLogger logr.Logger, o metav1.Object) error {
+	// This is based on the example code at:
+	// https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md#handle-cleanup-on-deletion
 	if len(o.GetFinalizers()) < 1 && o.GetDeletionTimestamp() == nil {
 		reqLogger.Info("Adding Finalizer to the PushApplication")
 		o.SetFinalizers([]string{"finalizer.push.aerogear.org"})

--- a/pkg/controller/util/add_finalizer.go
+++ b/pkg/controller/util/add_finalizer.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AddFinalizer will add a finalizer to the PushApplication CR so that
+// we can delete from UPS appropriately
+func AddFinalizer(client client.Client, reqLogger logr.Logger, o metav1.Object) error {
+	if len(o.GetFinalizers()) < 1 && o.GetDeletionTimestamp() == nil {
+		reqLogger.Info("Adding Finalizer to the PushApplication")
+		o.SetFinalizers([]string{"finalizer.push.aerogear.org"})
+
+		// Update CR
+		switch typedObject := o.(type) {
+		case runtime.Object:
+			err := client.Update(context.TODO(), typedObject)
+			if err != nil {
+				reqLogger.Error(err, "Failed to update a CR with a finalizer")
+				return err
+			}
+		default:
+			reqLogger.Info("Can't determine the type of thing to add finalizer to")
+		}
+	}
+	return nil
+}

--- a/pkg/controller/util/unifiedpushClient.go
+++ b/pkg/controller/util/unifiedpushClient.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aerogear/unifiedpush-operator/pkg/unifiedpush"
+)
+
+func UnifiedpushClient(kclient client.Client, reqLogger logr.Logger) (unifiedpush.UnifiedpushClient, error) {
+	listOptions := client.MatchingLabels(map[string]string{"internal": "unifiedpush"})
+
+	var foundServices corev1.ServiceList
+	err := kclient.List(context.TODO(), listOptions, &foundServices)
+	if err != nil {
+		return unifiedpush.UnifiedpushClient{}, err
+	}
+
+	if len(foundServices.Items) == 0 {
+		return unifiedpush.UnifiedpushClient{}, errors.New("Didn't find any UPS Services")
+	}
+
+	if len(foundServices.Items) > 1 {
+		reqLogger.Info("Found more than one internal UPS Service, using the first one")
+	}
+
+	upsUrl := fmt.Sprintf("http://%s", foundServices.Items[0].Name)
+	return unifiedpush.UnifiedpushClient{upsUrl}, nil
+}

--- a/pkg/unifiedpush/client.go
+++ b/pkg/unifiedpush/client.go
@@ -133,15 +133,40 @@ func (c UnifiedpushClient) DeleteApplication(p *pushv1alpha1.PushApplication) er
 	return nil
 }
 
+// GetAndroidVariant does a GET for a given Variant based on the VariantId
+func (c UnifiedpushClient) GetAndroidVariant(v *pushv1alpha1.AndroidVariant) (string, error) {
+	if v.Status.VariantId == "" {
+		// We haven't created it yet
+		return "", nil
+	}
+
+	url := fmt.Sprintf("%s/rest/applications/%s/android/%s", c.Url, v.Spec.PushApplicationId, v.Status.VariantId)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	resp, err := doUPSRequest(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var foundVariant androidVariant
+	b, _ := ioutil.ReadAll(resp.Body)
+	json.Unmarshal(b, &foundVariant)
+	fmt.Printf("Found app: %v\n", foundVariant)
+
+	// TODO: maybe now it's time to start using the "API types"
+	return foundVariant.VariantId, nil
+}
+
 // CreateAndroidVariant creates a Variant on an Application in UPS
-func (c UnifiedpushClient) CreateAndroidVariant(av *pushv1alpha1.AndroidVariant) (string, error) {
-	url := fmt.Sprintf("%s/rest/applications/%s/android", c.Url, av.Spec.PushApplicationId)
+func (c UnifiedpushClient) CreateAndroidVariant(v *pushv1alpha1.AndroidVariant) (string, error) {
+	url := fmt.Sprintf("%s/rest/applications/%s/android", c.Url, v.Spec.PushApplicationId)
 
 	params := map[string]string{
 		"projectNumber": "1",
-		"name":          av.Name,
-		"googleKey":     av.Spec.ServerKey,
-		"description":   av.Spec.Description,
+		"name":          v.Name,
+		"googleKey":     v.Spec.ServerKey,
+		"description":   v.Spec.Description,
 	}
 
 	payload, err := json.Marshal(params)
@@ -168,6 +193,53 @@ func (c UnifiedpushClient) CreateAndroidVariant(av *pushv1alpha1.AndroidVariant)
 	json.Unmarshal(b, &createdVariant)
 
 	return createdVariant.VariantId, nil
+}
+
+// DeleteAndroidVariant deletes an Android variant in UPS
+func (c UnifiedpushClient) DeleteAndroidVariant(v *pushv1alpha1.AndroidVariant) error {
+	if v.Status.VariantId == "" {
+		// We haven't created it yet
+		return nil
+	}
+
+	url := fmt.Sprintf("%s/rest/applications/%s/android/%s", c.Url, v.Spec.PushApplicationId, v.Status.VariantId)
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	resp, err := doUPSRequest(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 204 {
+		return errors.New(fmt.Sprintf("Expected a status code of 204 for variant deletion in UPS, but got %s", resp.StatusCode))
+	}
+
+	return nil
+}
+
+// GetIOSVariant does a GET for a given iOS Variant based on the VariantId
+func (c UnifiedpushClient) GetIOSVariant(v *pushv1alpha1.IOSVariant) (string, error) {
+	if v.Status.VariantId == "" {
+		// We haven't created it yet
+		return "", nil
+	}
+
+	url := fmt.Sprintf("%s/rest/applications/%s/ios/%s", c.Url, v.Spec.PushApplicationId, v.Status.VariantId)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	resp, err := doUPSRequest(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var foundVariant iOSVariant
+	b, _ := ioutil.ReadAll(resp.Body)
+	json.Unmarshal(b, &foundVariant)
+	fmt.Printf("Found app: %v\n", foundVariant)
+
+	// TODO: maybe now it's time to start using the "API types"
+	return foundVariant.VariantId, nil
 }
 
 // CreateIOSVariant creates a Variant on an Application in UPS
@@ -220,6 +292,28 @@ func (c UnifiedpushClient) CreateIOSVariant(v *pushv1alpha1.IOSVariant) (string,
 	json.Unmarshal(b, &createdVariant)
 
 	return createdVariant.VariantId, nil
+}
+
+// DeleteIOSVariant deletes an IOS variant in UPS
+func (c UnifiedpushClient) DeleteIOSVariant(v *pushv1alpha1.IOSVariant) error {
+	if v.Status.VariantId == "" {
+		// We haven't created it yet
+		return nil
+	}
+
+	url := fmt.Sprintf("%s/rest/applications/%s/ios/%s", c.Url, v.Spec.PushApplicationId, v.Status.VariantId)
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	resp, err := doUPSRequest(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 204 {
+		return errors.New(fmt.Sprintf("Expected a status code of 204 for variant deletion in UPS, but got %s", resp.StatusCode))
+	}
+
+	return nil
 }
 
 func doUPSRequest(req *http.Request) (*http.Response, error) {

--- a/pkg/unifiedpush/client.go
+++ b/pkg/unifiedpush/client.go
@@ -211,7 +211,7 @@ func (c UnifiedpushClient) DeleteAndroidVariant(v *pushv1alpha1.AndroidVariant) 
 	}
 
 	if resp.StatusCode != 204 {
-		return errors.New(fmt.Sprintf("Expected a status code of 204 for variant deletion in UPS, but got %s", resp.StatusCode))
+		return errors.New(fmt.Sprintf("Expected a status code of 204 for variant deletion in UPS, but got %v", resp.StatusCode))
 	}
 
 	return nil
@@ -310,7 +310,7 @@ func (c UnifiedpushClient) DeleteIOSVariant(v *pushv1alpha1.IOSVariant) error {
 	}
 
 	if resp.StatusCode != 204 {
-		return errors.New(fmt.Sprintf("Expected a status code of 204 for variant deletion in UPS, but got %s", resp.StatusCode))
+		return errors.New(fmt.Sprintf("Expected a status code of 204 for variant deletion in UPS, but got %v", resp.StatusCode))
 	}
 
 	return nil

--- a/pkg/unifiedpush/client.go
+++ b/pkg/unifiedpush/client.go
@@ -111,6 +111,28 @@ func (c UnifiedpushClient) CreateApplication(p *pushv1alpha1.PushApplication) (s
 	return createdApplication.PushApplicationId, createdApplication.MasterSecret, nil
 }
 
+// DeleteApplication deletes a PushApplication in UPS
+func (c UnifiedpushClient) DeleteApplication(p *pushv1alpha1.PushApplication) error {
+	if p.Status.PushApplicationId == "" {
+		return errors.New("No PushApplicationId set in the PushApplication status")
+	}
+
+	url := fmt.Sprintf("%s/rest/applications/%s", c.Url, p.Status.PushApplicationId)
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	resp, err := doUPSRequest(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		return errors.New(fmt.Sprintf("UPS responded with status code: %v, but expected 204", resp.StatusCode))
+	}
+
+	return nil
+}
+
 // CreateAndroidVariant creates a Variant on an Application in UPS
 func (c UnifiedpushClient) CreateAndroidVariant(av *pushv1alpha1.AndroidVariant) (string, error) {
 	url := fmt.Sprintf("%s/rest/applications/%s/android", c.Url, av.Spec.PushApplicationId)


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9022

----

## Verification steps

1. Deploy the operator:

```
make cluster/prepare
kubectl apply -n unifiedpush -f ./deploy/operator.yaml
```

2. Provision a UPS by creating a CR:

```
kubectl apply -n unifiedpush -f ./deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml
```

3. Create a PushApplication CR:

```
kubectl apply -n unifiedpush -f ./deploy/crds/push_v1alpha1_pushapplication_cr.yaml
```

- Ensure the PushApplication shows up in the list of applications in the UPS admin UI
- Ensure the PushApplication has the `pushApplicationId` and `masterSecret` fields populated in the CR status.

4. Create an AndroidVariant CR using the PushApplication ID:

```
cat deploy/crds/push_v1alpha1_androidvariant_cr.yaml | sed -e "s/pushApplicationId: '123456'/pushApplicationId: '$(kubectl get pushapplications -o jsonpath='{.items[0].status.pushApplicationId}')'/" | kubectl apply -f -
```

- Ensure the variant shows up under the Application in the UPS admin UI
- Ensure the AndroidVariant CR has a `status.variantId` populated, and `status.ready` is `true`
- Ensure the AndroidVariant CR has a `finalizer.push.aerogear.org` in `metadata.finalizers`

*Note:* You can do something equivalent to this for the IOSVariant if you've got a cert that you can use

5. Delete the AndroidVariant CR:

```
kubectl delete androidVariant example-androidvariant
```

- Ensure the Variant no longer appears in the UPS admin UI
- Ensure the CR is no longer accessible in Kubernetes

*Note:* You can do something equivalent to this for the IOSVariant if you've created one in step 4.

6. Delete the PushApplication CR:

```
kubectl delete pushApplication example-pushapplication
```

- Ensure the application no longer appears in the UPS admin UI
- Ensure the CR is no longer accessible in Kubernetes

7. Clean up!

```
make cluster/clean
```