### PR TITLE
fix: instructions in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -143,13 +143,13 @@ make code/run
 3. Create a UPS instance (in another terminal):
 
 ....
-kubectl apply -f deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml
+kubectl apply -f deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml -n unifiedpush
 ....
 
 4. Watch the status of your UPS instance provisioning (optional):
 
 ....
-watch -n1 "kubectl get po && echo '' && kubectl get ups -o yaml"
+watch -n1 "kubectl get po -n unifiedpush && echo '' && kubectl get ups -o yaml -n unifiedpush"
 ....
 
 5. When finished, clean up:


### PR DESCRIPTION
### Motivation
CR is created in a different namespace when "unifiedpush" namespace is not targeted (via `oc` or `kubectl`)

Hey @grdryn I'm not sure if this is the best way how to fix the instructions.
Other way could be to [target the namespace with kubectl command](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#setting-the-namespace-preference) but that way it wouldn't be [compatible with `oc`](https://github.com/aerogear/unifiedpush-operator/compare/master...fix-readme?quick_pull=1#diff-7bd4a925c695c2eb0eced3872b9b965fL126)
wdyt?