### PR TITLE
Limit creation of UPS instances to 1 for operator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -171,7 +171,7 @@ the `pushApplicationId` from the status, this will be needed to be
 able to create Variants:
 
 ....
-kubectl get PushApplication example-pushapplication -n unifiedpush -o jsonpath='{.status.pushApplicationId}'
+kubectl get pushApplication example-pushapplication -n unifiedpush -o jsonpath='{.status.pushApplicationId}'
 ....
 
 Here are all of the configurable fields in an AndroidVariant:

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -138,9 +139,40 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, err
 	}
 
+	// look for other unifiedPush resources and don't provision a new one if there is another one with Phase=Complete
+	existingInstances := &pushv1alpha1.UnifiedPushServerList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "UnifiedPushServer",
+			APIVersion: "push.aerogear.org/v1alpha1",
+		},
+	}
+	opts := &client.ListOptions{Namespace: instance.Namespace}
+	err = r.client.List(context.TODO(), opts, existingInstances)
+	if err != nil {
+		reqLogger.Error(err, "Failed to list UnifiedPush resources", "UnifiedPush.Namespace", instance.Namespace)
+		return reconcile.Result{}, err
+	} else if len(existingInstances.Items) > 1 { // check if > 1 since there's the current one already in that list.
+		for _, existingInstance := range existingInstances.Items {
+			if existingInstance.Name == instance.Name {
+				continue
+			}
+			if existingInstance.Status.Phase == pushv1alpha1.PhaseProvision || existingInstance.Status.Phase == pushv1alpha1.PhaseComplete {
+				reqLogger.Info("There is already a UnifiedPush resource in Complete phase. Doing nothing for this CR.", "UnifiedPush.Namespace", instance.Namespace, "UnifiedPush.Name", instance.Name)
+				return reconcile.Result{}, nil
+			}
+		}
+	}
+
 	if instance.Status.Phase == pushv1alpha1.PhaseEmpty {
 		instance.Status.Phase = pushv1alpha1.PhaseProvision
-		r.client.Status().Update(context.TODO(), instance)
+		err = r.client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			reqLogger.Error(err, "Failed to update UnifiedPush resource status phase", "UnifiedPush.Namespace", instance.Namespace, "UnifiedPush.Name", instance.Name)
+			return reconcile.Result{}, err
+		}
+	} else if instance.Status.Phase == pushv1alpha1.PhaseComplete {
+		reqLogger.Info("UnifiedPush resource is already in Complete phase. Doing nothing.", "UnifiedPush.Namespace", instance.Namespace, "UnifiedPush.Name", instance.Name)
+		return reconcile.Result{}, nil
 	}
 
 	persistentVolumeClaim, err := newPostgresqlPersistentVolumeClaim(instance)


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9335

Verification:

```
make cluster/clean
make cluster/prepare

# change the image to aliok/ups-opr-june13-02 in deploy/operator.yaml
kubectl create -n unifiedpush -f deploy/operator.yaml

# create first CR
kubectl create -n unifiedpush -f deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml

# change name in deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml to example-unifiedpushserver2
# create second CR
kubectl create -n unifiedpush -f deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml
```

See the operator logs:
```
{
  "level": "info",
  "ts": 1560430773.5477245,
  "logger": "controller_unifiedpushserver",
  "msg": "Reconciling UnifiedPushServer",
  "Request.Namespace": "unifiedpush",
  "Request.Name": "example-unifiedpushserver2"
}
{
  "level": "info",
  "ts": 1560430773.547797,
  "logger": "controller_unifiedpushserver",
  "msg": "There is already a UnifiedPush resource in Complete phase. Doing nothing for this CR.",
  "Request.Namespace": "unifiedpush",
  "Request.Name": "example-unifiedpushserver2",
  "UnifiedPush.Namespace": "unifiedpush",
  "UnifiedPush.Name": "example-unifiedpushserver2"
}
```

Also, no new UPS instance should be created.