### PR TITLE
AEROGEAR-9434 use ImageStreams

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aerogear/unifiedpush-operator/pkg/apis"
 	"github.com/aerogear/unifiedpush-operator/pkg/controller"
 
+	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -104,6 +105,12 @@ func main() {
 
 	// Setup Scheme for OpenShift Route
 	if err := routev1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Setup Scheme for OpenShift Apis
+	if err := openshiftappsv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aerogear/unifiedpush-operator/pkg/controller"
 
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -111,6 +112,12 @@ func main() {
 
 	// Setup Scheme for OpenShift Apis
 	if err := openshiftappsv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Setup Scheme for OpenShift Image apis
+	if err := imagev1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: unifiedpush-operator
 rules:
 - apiGroups:
@@ -57,5 +56,17 @@ rules:
   - push.aerogear.org
   resources:
   - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
   verbs:
   - '*'

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -10,16 +10,3 @@ roleRef:
   kind: ClusterRole
   name: unifiedpush-operator
   apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: unifiedpush-operator-image-import
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:openshift:controller:image-import-controller
-subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:masters

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -10,3 +10,16 @@ roleRef:
   kind: ClusterRole
   name: unifiedpush-operator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: unifiedpush-operator-image-import
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:controller:image-import-controller
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:masters

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,10 +9,12 @@ type Config struct {
 
 	UPSImageStreamName        string
 	UPSImageStreamTag         string
-	PostgresImageStreamName   string
-	PostgresImageStreamTag    string
 	OauthProxyImageStreamName string
 	OauthProxyImageStreamTag  string
+
+	PostgresImageStreamNamespace string
+	PostgresImageStreamName      string
+	PostgresImageStreamTag       string
 
 	UPSImageStreamInitialImage        string
 	PostgresImageStreamInitialImage   string
@@ -27,14 +29,15 @@ func New() Config {
 
 		UPSImageStreamName:        getEnv("UPS_IMAGE_STREAM_NAME", "ups-imagestream"),
 		UPSImageStreamTag:         getEnv("UPS_IMAGE_STREAM_TAG", "latest"),
-		PostgresImageStreamName:   getEnv("POSTGRES_IMAGE_STREAM_NAME", "ups-postgres-imagestream"),
-		PostgresImageStreamTag:    getEnv("POSTGRES_IMAGE_STREAM_TAG", "latest"),
 		OauthProxyImageStreamName: getEnv("OAUTH_PROXY_IMAGE_STREAM_NAME", "ups-oauth-proxy-imagestream"),
 		OauthProxyImageStreamTag:  getEnv("OAUTH_PROXY_IMAGE_STREAM_TAG", "latest"),
 
+		PostgresImageStreamNamespace: getEnv("POSTGRES_IMAGE_STREAM_NAMESPACE", "openshift"),
+		PostgresImageStreamName:      getEnv("POSTGRES_IMAGE_STREAM_NAME", "postgresql"),
+		PostgresImageStreamTag:       getEnv("POSTGRES_IMAGE_STREAM_TAG", "latest"),
+
 		// these are used when the image stream does not exist and created for the first time by the operator
 		UPSImageStreamInitialImage:        getEnv("UPS_IMAGE_STREAM_INITIAL_IMAGE", "docker.io/aerogear/unifiedpush-wildfly-plain:2.2.1.Final"),
-		PostgresImageStreamInitialImage:   getEnv("POSTGRES_IMAGE_STREAM_INITIAL_IMAGE", "docker.io/centos/postgresql-96-centos7:9.6"),
 		OauthProxyImageStreamInitialImage: getEnv("OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE", "docker.io/openshift/oauth-proxy:v1.1.0"),
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,48 @@
+package config
+
+import "os"
+
+type Config struct {
+	UPSContainerName        string
+	PostgresContainerName   string
+	OauthProxyContainerName string
+
+	UPSImageStreamName        string
+	UPSImageStreamTag         string
+	PostgresImageStreamName   string
+	PostgresImageStreamTag    string
+	OauthProxyImageStreamName string
+	OauthProxyImageStreamTag  string
+
+	UPSImageStreamInitialImage        string
+	PostgresImageStreamInitialImage   string
+	OauthProxyImageStreamInitialImage string
+}
+
+func New() Config {
+	return Config{
+		UPSContainerName:        getEnv("UPS_CONTAINER_NAME", "ups"),
+		PostgresContainerName:   getEnv("POSTGRES_CONTAINER_NAME", "postgresql"),
+		OauthProxyContainerName: getEnv("OAUTH_PROXY_CONTAINER_NAME", "ups-oauth-proxy"),
+
+		UPSImageStreamName:        getEnv("UPS_IMAGE_STREAM_NAME", "ups-imagestream"),
+		UPSImageStreamTag:         getEnv("UPS_IMAGE_STREAM_TAG", "latest"),
+		PostgresImageStreamName:   getEnv("POSTGRES_IMAGE_STREAM_NAME", "ups-postgres-imagestream"),
+		PostgresImageStreamTag:    getEnv("POSTGRES_IMAGE_STREAM_TAG", "latest"),
+		OauthProxyImageStreamName: getEnv("OAUTH_PROXY_IMAGE_STREAM_NAME", "ups-oauth-proxy-imagestream"),
+		OauthProxyImageStreamTag:  getEnv("OAUTH_PROXY_IMAGE_STREAM_TAG", "latest"),
+
+		// these are used when the image stream does not exist and created for the first time by the operator
+		UPSImageStreamInitialImage:        getEnv("UPS_IMAGE_STREAM_INITIAL_IMAGE", "docker.io/aerogear/unifiedpush-wildfly-plain:2.2.1.Final"),
+		PostgresImageStreamInitialImage:   getEnv("POSTGRES_IMAGE_STREAM_INITIAL_IMAGE", "docker.io/centos/postgresql-96-centos7:9.6"),
+		OauthProxyImageStreamInitialImage: getEnv("OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE", "docker.io/openshift/oauth-proxy:v1.1.0"),
+	}
+}
+
+func getEnv(key string, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+
+	return defaultVal
+}

--- a/pkg/controller/unifiedpushserver/constants.go
+++ b/pkg/controller/unifiedpushserver/constants.go
@@ -1,7 +1,0 @@
-package unifiedpushserver
-
-const (
-	UPS_CONTAINER_NAME         = "ups"
-	OAUTH_PROXY_CONTAINER_NAME = "ups-oauth-proxy"
-	POSTGRES_CONTAINER_NAME    = "postgresql"
-)

--- a/pkg/controller/unifiedpushserver/postgresql.go
+++ b/pkg/controller/unifiedpushserver/postgresql.go
@@ -5,8 +5,6 @@ import (
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
-	imagev1 "github.com/openshift/api/image/v1"
-
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -68,8 +66,9 @@ func newPostgresqlDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*openshi
 						Automatic:      true,
 						ContainerNames: []string{cfg.PostgresContainerName},
 						From: corev1.ObjectReference{
-							Kind: "ImageStreamTag",
-							Name: cfg.PostgresImageStreamName + ":" + cfg.PostgresImageStreamTag,
+							Kind:      "ImageStreamTag",
+							Namespace: cfg.PostgresImageStreamNamespace,
+							Name:      cfg.PostgresImageStreamName + ":" + cfg.PostgresImageStreamTag,
 						},
 					},
 				},
@@ -189,30 +188,6 @@ func newPostgresqlService(cr *pushv1alpha1.UnifiedPushServer) (*corev1.Service, 
 					Name:     "postgresql",
 					Protocol: corev1.ProtocolTCP,
 					Port:     5432,
-				},
-			},
-		},
-	}, nil
-}
-
-func newPostgresImageStream(cr *pushv1alpha1.UnifiedPushServer) (*imagev1.ImageStream, error) {
-	return &imagev1.ImageStream{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: cr.Namespace,
-			Name:      cfg.PostgresImageStreamName,
-			Labels:    labels(cr, cfg.PostgresImageStreamName),
-		},
-		Spec: imagev1.ImageStreamSpec{
-			Tags: []imagev1.TagReference{
-				{
-					Name: cfg.PostgresImageStreamTag,
-					From: &corev1.ObjectReference{
-						Kind: "DockerImage",
-						Name: cfg.PostgresImageStreamInitialImage,
-					},
-					ImportPolicy: imagev1.TagImportPolicy{
-						Scheduled: true,
-					},
 				},
 			},
 		},

--- a/pkg/controller/unifiedpushserver/postgresql.go
+++ b/pkg/controller/unifiedpushserver/postgresql.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
+	openshiftappsv1 "github.com/openshift/api/apps/v1"
 
 	"github.com/pkg/errors"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,19 +49,18 @@ func newPostgresqlSecret(cr *pushv1alpha1.UnifiedPushServer) (*corev1.Secret, er
 	}, nil
 }
 
-func newPostgresqlDeployment(cr *pushv1alpha1.UnifiedPushServer) (*appsv1.Deployment, error) {
+func newPostgresqlDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*openshiftappsv1.DeploymentConfig, error) {
 	memoryLimit, err := resource.ParseQuantity("512Mi")
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing PostgreSQL container memory limit size")
 	}
 
-	return &appsv1.Deployment{
+	return &openshiftappsv1.DeploymentConfig{
 		ObjectMeta: objectMeta(cr, "postgresql"),
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: labels(cr, "postgresql"),
-			},
-			Template: corev1.PodTemplateSpec{
+		Spec: openshiftappsv1.DeploymentConfigSpec{
+			Replicas: 1,
+			Selector: labels(cr, "postgresql"),
+			Template: &corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels(cr, "postgresql"),
 				},

--- a/pkg/controller/unifiedpushserver/postgresql.go
+++ b/pkg/controller/unifiedpushserver/postgresql.go
@@ -69,7 +69,7 @@ func newPostgresqlDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*openshi
 					Containers: []corev1.Container{
 						{
 							Name:            cfg.PostgresContainerName,
-							Image:           cfg.PostgresImageStreamInitialImage, // TODO: use image streams
+							Image:           cfg.PostgresImageStreamName + ":" + cfg.PostgresImageStreamTag,
 							ImagePullPolicy: corev1.PullAlways,
 							Env: []corev1.EnvVar{
 								{

--- a/pkg/controller/unifiedpushserver/postgresql.go
+++ b/pkg/controller/unifiedpushserver/postgresql.go
@@ -67,8 +67,8 @@ func newPostgresqlDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*openshi
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:            POSTGRES_CONTAINER_NAME,
-							Image:           postgresql.image(),
+							Name:            cfg.PostgresContainerName,
+							Image:           cfg.PostgresImageStreamInitialImage, // TODO: use image streams
 							ImagePullPolicy: corev1.PullAlways,
 							Env: []corev1.EnvVar{
 								{
@@ -107,7 +107,7 @@ func newPostgresqlDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*openshi
 							},
 							Ports: []corev1.ContainerPort{
 								{
-									Name:          POSTGRES_CONTAINER_NAME,
+									Name:          cfg.PostgresContainerName,
 									Protocol:      corev1.ProtocolTCP,
 									ContainerPort: 5432,
 								},

--- a/pkg/controller/unifiedpushserver/postgresql.go
+++ b/pkg/controller/unifiedpushserver/postgresql.go
@@ -61,6 +61,19 @@ func newPostgresqlDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*openshi
 		Spec: openshiftappsv1.DeploymentConfigSpec{
 			Replicas: 1,
 			Selector: labels(cr, "postgresql"),
+			Triggers: openshiftappsv1.DeploymentTriggerPolicies{
+				openshiftappsv1.DeploymentTriggerPolicy{
+					Type: openshiftappsv1.DeploymentTriggerOnImageChange,
+					ImageChangeParams: &openshiftappsv1.DeploymentTriggerImageChangeParams{
+						Automatic:      true,
+						ContainerNames: []string{cfg.PostgresContainerName},
+						From: corev1.ObjectReference{
+							Kind: "ImageStreamTag",
+							Name: cfg.PostgresImageStreamName + ":" + cfg.PostgresImageStreamTag,
+						},
+					},
+				},
+			},
 			Template: &corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels(cr, "postgresql"),

--- a/pkg/controller/unifiedpushserver/postgresql.go
+++ b/pkg/controller/unifiedpushserver/postgresql.go
@@ -5,6 +5,7 @@ import (
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/pkg/errors"
 
@@ -175,6 +176,30 @@ func newPostgresqlService(cr *pushv1alpha1.UnifiedPushServer) (*corev1.Service, 
 					Name:     "postgresql",
 					Protocol: corev1.ProtocolTCP,
 					Port:     5432,
+				},
+			},
+		},
+	}, nil
+}
+
+func newPostgresImageStream(cr *pushv1alpha1.UnifiedPushServer) (*imagev1.ImageStream, error) {
+	return &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cr.Namespace,
+			Name:      cfg.PostgresImageStreamName,
+			Labels:    labels(cr, cfg.PostgresImageStreamName),
+		},
+		Spec: imagev1.ImageStreamSpec{
+			Tags: []imagev1.TagReference{
+				{
+					Name: cfg.PostgresImageStreamTag,
+					From: &corev1.ObjectReference{
+						Kind: "DockerImage",
+						Name: cfg.PostgresImageStreamInitialImage,
+					},
+					ImportPolicy: imagev1.TagImportPolicy{
+						Scheduled: true,
+					},
 				},
 			},
 		},

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -128,17 +128,6 @@ func newUnifiedPushServerDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*
 					Type: openshiftappsv1.DeploymentTriggerOnImageChange,
 					ImageChangeParams: &openshiftappsv1.DeploymentTriggerImageChangeParams{
 						Automatic:      true,
-						ContainerNames: []string{cfg.PostgresContainerName},
-						From: corev1.ObjectReference{
-							Kind: "ImageStreamTag",
-							Name: cfg.PostgresImageStreamName + ":" + cfg.PostgresImageStreamTag,
-						},
-					},
-				},
-				openshiftappsv1.DeploymentTriggerPolicy{
-					Type: openshiftappsv1.DeploymentTriggerOnImageChange,
-					ImageChangeParams: &openshiftappsv1.DeploymentTriggerImageChangeParams{
-						Automatic:      true,
 						ContainerNames: []string{cfg.OauthProxyContainerName},
 						From: corev1.ObjectReference{
 							Kind: "ImageStreamTag",

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
+	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -64,7 +64,7 @@ func newOauthProxyRoute(cr *pushv1alpha1.UnifiedPushServer) (*routev1.Route, err
 	}, nil
 }
 
-func newUnifiedPushServerDeployment(cr *pushv1alpha1.UnifiedPushServer) (*appsv1.Deployment, error) {
+func newUnifiedPushServerDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*openshiftappsv1.DeploymentConfig, error) {
 	labels := map[string]string{
 		"app":     cr.Name,
 		"service": "ups",
@@ -75,17 +75,16 @@ func newUnifiedPushServerDeployment(cr *pushv1alpha1.UnifiedPushServer) (*appsv1
 		return nil, errors.Wrap(err, "error generating cookie secret")
 	}
 
-	return &appsv1.Deployment{
+	return &openshiftappsv1.DeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
-			},
-			Template: corev1.PodTemplateSpec{
+		Spec: openshiftappsv1.DeploymentConfigSpec{
+			Replicas: 1,
+			Selector: labels,
+			Template: &corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
 				},

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -81,7 +81,7 @@ func newOauthProxyImageStream(cr *pushv1alpha1.UnifiedPushServer) (*imagev1.Imag
 						Name: cfg.OauthProxyImageStreamInitialImage,
 					},
 					ImportPolicy: imagev1.TagImportPolicy{
-						Scheduled: true,
+						Scheduled: false,
 					},
 				},
 			},
@@ -328,7 +328,7 @@ func newUnifiedPushImageStream(cr *pushv1alpha1.UnifiedPushServer) (*imagev1.Ima
 						Name: cfg.UPSImageStreamInitialImage,
 					},
 					ImportPolicy: imagev1.TagImportPolicy{
-						Scheduled: true,
+						Scheduled: false,
 					},
 				},
 			},

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -5,6 +5,7 @@ import (
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -257,6 +258,30 @@ func newUnifiedPushServerService(cr *pushv1alpha1.UnifiedPushServer) (*corev1.Se
 					TargetPort: intstr.IntOrString{
 						Type:   intstr.Int,
 						IntVal: 8080,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func newUnifiedPushImageStream(cr *pushv1alpha1.UnifiedPushServer) (*imagev1.ImageStream, error) {
+	return &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cr.Namespace,
+			Name:      cfg.UPSImageStreamName,
+			Labels:    labels(cr, cfg.UPSImageStreamName),
+		},
+		Spec: imagev1.ImageStreamSpec{
+			Tags: []imagev1.TagReference{
+				{
+					Name: cfg.UPSImageStreamTag,
+					From: &corev1.ObjectReference{
+						Kind: "DockerImage",
+						Name: cfg.UPSImageStreamInitialImage,
+					},
+					ImportPolicy: imagev1.TagImportPolicy{
+						Scheduled: true,
 					},
 				},
 			},

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -135,6 +135,18 @@ func newUnifiedPushServerDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*
 						},
 					},
 				},
+				openshiftappsv1.DeploymentTriggerPolicy{
+					Type: openshiftappsv1.DeploymentTriggerOnImageChange,
+					ImageChangeParams: &openshiftappsv1.DeploymentTriggerImageChangeParams{
+						Automatic:      true,
+						ContainerNames: []string{cfg.PostgresContainerName},
+						From: corev1.ObjectReference{
+							Kind:      "ImageStreamTag",
+							Namespace: cfg.PostgresImageStreamNamespace,
+							Name:      cfg.PostgresImageStreamName + ":" + cfg.PostgresImageStreamTag,
+						},
+					},
+				},
 			},
 			Template: &corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -213,31 +213,6 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	}
 	//#endregion
 
-	//#region Postgres ImageStream
-	postgresImageStream, err := newPostgresImageStream(instance)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Set UnifiedPushServer instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, postgresImageStream, r.scheme); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Check if this ImageStream already exists
-	foundPostgresImageStream := &imagev1.ImageStream{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: postgresImageStream.Name, Namespace: postgresImageStream.Namespace}, foundPostgresImageStream)
-	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Creating a new ImageStream", "ImageStream.Namespace", postgresImageStream.Namespace, "ImageStream.Name", postgresImageStream.Name)
-		err = r.client.Create(context.TODO(), postgresImageStream)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-	} else if err != nil {
-		return reconcile.Result{}, err
-	}
-	//#endregion
-
 	//#region Postgres DeploymentConfig
 	postgresqlDeploymentConfig, err := newPostgresqlDeploymentConfig(instance)
 	if err != nil {

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -23,10 +23,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller_unifiedpushserver")
-
 var (
 	cfg = config.New()
+	log = logf.Log.WithName("controller_unifiedpushserver")
 )
 
 // Add creates a new UnifiedPushServer Controller and adds it to the Manager. The Manager will set fields on the Controller

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -8,7 +8,6 @@ import (
 
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,16 +50,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to primary resource UnifiedPushServer
 	err = c.Watch(&source.Kind{Type: &pushv1alpha1.UnifiedPushServer{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		return err
-	}
-
-	// TODO: still need following? probably not!
-	// Watch for changes to secondary resource Deployment and requeue the owner UnifiedPushServer
-	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &pushv1alpha1.UnifiedPushServer{},
-	})
 	if err != nil {
 		return err
 	}
@@ -261,7 +250,7 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, err
 	}
 
-	// Check if this Deployment already exists
+	// Check if this DeploymentConfig already exists
 	foundPostgresqlDeploymentConfig := &openshiftappsv1.DeploymentConfig{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: postgresqlDeploymentConfig.Name, Namespace: postgresqlDeploymentConfig.Namespace}, foundPostgresqlDeploymentConfig)
 	if err != nil && errors.IsNotFound(err) {

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -200,6 +200,7 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, nil
 	}
 
+	//#region Postgres PVC
 	persistentVolumeClaim, err := newPostgresqlPersistentVolumeClaim(instance)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -222,7 +223,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
+	//#endregion
 
+	//#region Postgres DeploymentConfig
 	postgresqlDeploymentConfig, err := newPostgresqlDeploymentConfig(instance)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -244,28 +247,10 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 		}
 	} else if err != nil {
 		return reconcile.Result{}, err
-	} else {
-		//desiredImage := postgresql.image()
-		//
-		//containerSpec := findContainerSpec(foundPostgresqlDeploymentConfig, POSTGRES_CONTAINER_NAME)
-		//if containerSpec == nil {
-		//	reqLogger.Info("Skipping image reconcile: Unable to find container spec in deployment", "Deployment.Namespace", foundPostgresqlDeploymentConfig.Namespace, "Deployment.Name", foundPostgresqlDeploymentConfig.Name, "ContainerSpec", POSTGRES_CONTAINER_NAME)
-		//} else if containerSpec.Image != desiredImage {
-		//	reqLogger.Info("Container spec in deployment is using a different image. Going to update it now.", "Deployment.Namespace", foundPostgresqlDeploymentConfig.Namespace, "Deployment.Name", foundPostgresqlDeploymentConfig.Name, "ContainerSpec", POSTGRES_CONTAINER_NAME, "ExistingImage", containerSpec.Image, "DesiredImage", desiredImage)
-		//
-		//	// update
-		//	updateContainerSpecImage(foundPostgresqlDeploymentConfig, POSTGRES_CONTAINER_NAME, desiredImage)
-		//
-		//	// enqueue
-		//	err = r.client.Update(context.TODO(), foundPostgresqlDeploymentConfig)
-		//	if err != nil {
-		//		reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundPostgresqlDeploymentConfig.Namespace, "Deployment.Name", foundPostgresqlDeploymentConfig.Name)
-		//		return reconcile.Result{}, err
-		//	}
-		//	return reconcile.Result{Requeue: true}, nil
-		//}
 	}
+	//#endregion
 
+	//#region Postgres Service
 	postgresqlService, err := newPostgresqlService(instance)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -288,7 +273,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
+	//#endregion
 
+	//#region ServiceAccount
 	serviceAccount, err := newUnifiedPushServiceAccount(instance)
 
 	// Set UnifiedPushServer instance as the owner and controller
@@ -308,7 +295,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
+	//#endregion
 
+	//#region Postgres Secret
 	postgresqlSecret, err := newPostgresqlSecret(instance)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -331,7 +320,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
+	//#endregion
 
+	//#region OauthProxy Service
 	oauthProxyService, err := newOauthProxyService(instance)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -354,7 +345,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
+	//#endregion
 
+	//#region UPS Service
 	unifiedpushService, err := newUnifiedPushServerService(instance)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -377,7 +370,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
+	//#endregion
 
+	//#region OauthProxy Route
 	oauthProxyRoute, err := newOauthProxyRoute(instance)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -400,8 +395,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
+	//#endregion
 
-	// Define a new ImageStream
+	//#region UPS ImageStream
 	unifiedPushImageStream, err := newUnifiedPushImageStream(instance)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -424,8 +420,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
+	//#endregion
 
-	// Define a new DeploymentConfig object
+	//#region UPS DeploymentConfig
 	unifiedpushDeploymentConfig, err := newUnifiedPushServerDeploymentConfig(instance)
 
 	if err := controllerutil.SetControllerReference(instance, unifiedpushDeploymentConfig, r.scheme); err != nil {
@@ -446,48 +443,8 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, nil
 	} else if err != nil {
 		return reconcile.Result{}, err
-	} else {
-		//fou
-
-		//desiredUnifiedPushImage := unifiedpush.image()
-		//desiredProxyImage := proxy.image()
-		//
-		//unifiedPushContainerSpec := findContainerSpec(foundUnifiedpushDeploymentConfig, UPS_CONTAINER_NAME)
-		//if unifiedPushContainerSpec == nil {
-		//	reqLogger.Info("Skipping image reconcile: Unable to find container spec in deployment", "Deployment.Namespace", foundUnifiedpushDeploymentConfig.Namespace, "Deployment.Name", foundUnifiedpushDeploymentConfig.Name, "ContainerSpec", UPS_CONTAINER_NAME)
-		//} else if unifiedPushContainerSpec.Image != desiredUnifiedPushImage {
-		//	reqLogger.Info("Container spec in deployment is using a different image. Going to update it now.", "Deployment.Namespace", foundUnifiedpushDeploymentConfig.Namespace, "Deployment.Name", foundUnifiedpushDeploymentConfig.Name, "ContainerSpec", UPS_CONTAINER_NAME, "ExistingImage", unifiedPushContainerSpec.Image, "DesiredImage", desiredUnifiedPushImage)
-		//
-		//	// update
-		//	updateContainerSpecImage(foundUnifiedpushDeploymentConfig, UPS_CONTAINER_NAME, desiredUnifiedPushImage)
-		//
-		//	// enqueue
-		//	err = r.client.Update(context.TODO(), foundUnifiedpushDeploymentConfig)
-		//	if err != nil {
-		//		reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeploymentConfig.Namespace, "Deployment.Name", foundUnifiedpushDeploymentConfig.Name)
-		//		return reconcile.Result{}, err
-		//	}
-		//	return reconcile.Result{Requeue: true}, nil
-		//}
-		//
-		//proxyContainerSpec := findContainerSpec(foundUnifiedpushDeploymentConfig, OAUTH_PROXY_CONTAINER_NAME)
-		//if proxyContainerSpec == nil {
-		//	reqLogger.Info("Skipping image reconcile: Unable to find container spec in deployment", "Deployment.Namespace", foundUnifiedpushDeploymentConfig.Namespace, "Deployment.Name", foundUnifiedpushDeploymentConfig.Name, "ContainerSpec", OAUTH_PROXY_CONTAINER_NAME)
-		//} else if proxyContainerSpec.Image != desiredProxyImage {
-		//	reqLogger.Info("Container spec in deployment is using a different image. Going to update it now.", "Deployment.Namespace", foundUnifiedpushDeploymentConfig.Namespace, "Deployment.Name", foundUnifiedpushDeploymentConfig.Name, "ContainerSpec", OAUTH_PROXY_CONTAINER_NAME, "ExistingImage", proxyContainerSpec.Image, "DesiredImage", desiredProxyImage)
-		//
-		//	// update
-		//	updateContainerSpecImage(foundUnifiedpushDeploymentConfig, OAUTH_PROXY_CONTAINER_NAME, desiredProxyImage)
-		//
-		//	// enqueue
-		//	err = r.client.Update(context.TODO(), foundUnifiedpushDeploymentConfig)
-		//	if err != nil {
-		//		reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeploymentConfig.Namespace, "Deployment.Name", foundUnifiedpushDeploymentConfig.Name)
-		//		return reconcile.Result{}, err
-		//	}
-		//	return reconcile.Result{Requeue: true}, nil
-		//}
 	}
+	//#endregion
 
 	if foundUnifiedpushDeploymentConfig.Status.ReadyReplicas > 0 && instance.Status.Phase != pushv1alpha1.PhaseComplete {
 		instance.Status.Phase = pushv1alpha1.PhaseComplete

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -225,6 +225,31 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	}
 	//#endregion
 
+	//#region Postgres ImageStream
+	postgresImageStream, err := newPostgresImageStream(instance)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Set UnifiedPushServer instance as the owner and controller
+	if err := controllerutil.SetControllerReference(instance, postgresImageStream, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Check if this ImageStream already exists
+	foundPostgresImageStream := &imagev1.ImageStream{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: postgresImageStream.Name, Namespace: postgresImageStream.Namespace}, foundPostgresImageStream)
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Creating a new ImageStream", "ImageStream.Namespace", postgresImageStream.Namespace, "ImageStream.Name", postgresImageStream.Name)
+		err = r.client.Create(context.TODO(), postgresImageStream)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+	//#endregion
+
 	//#region Postgres DeploymentConfig
 	postgresqlDeploymentConfig, err := newPostgresqlDeploymentConfig(instance)
 	if err != nil {
@@ -389,6 +414,31 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new Route", "Route.Namespace", oauthProxyRoute.Namespace, "Route.Name", oauthProxyRoute.Name)
 		err = r.client.Create(context.TODO(), oauthProxyRoute)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+	//#endregion
+
+	//#region OauthProxy ImageStream
+	oauthProxyImageStream, err := newOauthProxyImageStream(instance)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Set UnifiedPushServer instance as the owner and controller
+	if err := controllerutil.SetControllerReference(instance, oauthProxyImageStream, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Check if this ImageStream already exists
+	foundOauthProxyImageStream := &imagev1.ImageStream{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: foundOauthProxyImageStream.Name, Namespace: oauthProxyImageStream.Namespace}, foundOauthProxyImageStream)
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Creating a new ImageStream", "ImageStream.Namespace", foundOauthProxyImageStream.Namespace, "ImageStream.Name", oauthProxyImageStream.Name)
+		err = r.client.Create(context.TODO(), oauthProxyImageStream)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -2,8 +2,8 @@ package unifiedpushserver
 
 import (
 	"context"
-
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
+	"github.com/aerogear/unifiedpush-operator/pkg/config"
 	routev1 "github.com/openshift/api/route/v1"
 
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
@@ -24,6 +24,10 @@ import (
 )
 
 var log = logf.Log.WithName("controller_unifiedpushserver")
+
+var (
+	cfg = config.New()
+)
 
 // Add creates a new UnifiedPushServer Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/unifiedpushserver/util.go
+++ b/pkg/controller/unifiedpushserver/util.go
@@ -2,8 +2,6 @@ package unifiedpushserver
 
 import (
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
@@ -34,30 +32,4 @@ func generatePassword() (string, error) {
 		return "", errors.Wrap(err, "error generating password")
 	}
 	return strings.Replace(generatedPassword.String(), "-", "", -1), nil
-}
-
-func findContainerSpec(deployment *appsv1.Deployment, name string) *corev1.Container {
-	if deployment == nil || &deployment.Spec == nil || &deployment.Spec.Template == nil || &deployment.Spec.Template.Spec == nil || &deployment.Spec.Template.Spec.Containers == nil || len(deployment.Spec.Template.Spec.Containers) == 0 {
-		return nil
-	}
-
-	for _, spec := range deployment.Spec.Template.Spec.Containers {
-		if spec.Name == name {
-			return &spec
-		}
-	}
-
-	return nil
-}
-
-func updateContainerSpecImage(deployment *appsv1.Deployment, name string, image string) {
-	if deployment == nil || &deployment.Spec == nil || &deployment.Spec.Template == nil || &deployment.Spec.Template.Spec == nil || &deployment.Spec.Template.Spec.Containers == nil || len(deployment.Spec.Template.Spec.Containers) == 0 {
-		return
-	}
-
-	for idx, spec := range deployment.Spec.Template.Spec.Containers {
-		if spec.Name == name {
-			deployment.Spec.Template.Spec.Containers[idx].Image = image
-		}
-	}
 }

--- a/pkg/controller/unifiedpushserver/util.go
+++ b/pkg/controller/unifiedpushserver/util.go
@@ -4,32 +4,12 @@ import (
 	"fmt"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"os"
 	"strings"
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-type image struct {
-	defaultImage string
-	envVarName   string
-}
-
-func (i image) image() string {
-	customImage, found := os.LookupEnv(i.envVarName)
-	if found {
-		return customImage
-	}
-	return i.defaultImage
-}
-
-var (
-	proxy       = image{"docker.io/openshift/oauth-proxy:v1.1.0", "OAUTH_PROXY_IMAGE"}
-	postgresql  = image{"docker.io/centos/postgresql-96-centos7:9.6", "POSTGRESQL_IMAGE"}
-	unifiedpush = image{"docker.io/aerogear/unifiedpush-wildfly-plain:2.2.1.Final", "UNIFIEDPUSH_IMAGE"}
 )
 
 func labels(cr *pushv1alpha1.UnifiedPushServer, suffix string) map[string]string {


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9434

Use ImageStreams for UPS and its deps (OauthProxy, Postgres).
Also switched from plain Kube Deployments to DeploymentConfigs.

Verification:
* You can deploy the prebuilt image: aliok/ups-opr-jun25-4
* Deploy the operator
* Create unifiedpush CR
* Check the created DeploymentConfigs, Pods, ImageStreams in OpenShift Console
* Delete the CR
* Check if all the resources above are deleted.

Gonna squash my commits after approval.