### PR TITLE
feat(Monitor) : Add Prometheus Rules and Alerts for UPS Server (INTLY-1441) (INTLY-1442)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,15 +84,19 @@ monitoring/install:
 	- kubectl create -n $(NAMESPACE) -f deploy/monitor/operator_service.yaml
 	- kubectl create -n $(NAMESPACE) -f deploy/monitor/prometheus_rule.yaml
 	- kubectl create -n $(NAMESPACE) -f deploy/monitor/grafana_dashboard.yaml
+	- kubectl create -n $(NAMESPACE) -f deploy/monitor/push_service_monitor.yaml
+	- kubectl create -n $(NAMESPACE) -f deploy/monitor/push_prometheus_rule.yaml
 
 .PHONY: monitoring/uninstall
 monitoring/uninstall:
 	@echo Uninstalling monitor service from ${NAMESPACE} :
 	- oc project ${NAMESPACE}
 	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/service_monitor.yaml
-	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/operator_service.yaml
 	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/prometheus_rule.yaml
 	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/grafana_dashboard.yaml
+	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/push_service_monitor.yaml
+	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/push_prometheus_rule.yaml
+	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/operator_service.yaml
 
 .PHONY: example-pushapplication/apply
 example-pushapplication/apply:

--- a/deploy/monitor/grafana_dashboard.yaml
+++ b/deploy/monitor/grafana_dashboard.yaml
@@ -60,7 +60,7 @@ spec:
             }
           ]
         },
-        "description": "Application metrics",
+        "description": "Operator metrics",
         "editable": true,
         "gnetId": null,
         "graphTooltip": 0,
@@ -402,7 +402,7 @@ spec:
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,
-                "legendFormat": "UPS Operator- CPU Usage in Millicores",
+                "legendFormat": "UnifiedPush Operator- CPU Usage in Millicores",
                 "refId": "A",
                 "step": 2
               }
@@ -487,8 +487,8 @@ spec:
           ]
         },
         "timezone": "browser",
-        "title": "UPS Operator",
+        "title": "UnifiedPush Operator",
         "uid": "null",
         "version": 2
       }
-  name: unifiedpush.json
+  name: unifiedpushoperator.json

--- a/deploy/monitor/prometheus_rule.yaml
+++ b/deploy/monitor/prometheus_rule.yaml
@@ -20,13 +20,13 @@ spec:
         labels:
           severity: critical
         annotations:
-          description: "The unifiedpush-operator has been down for more than 5 minutes. "
-          summary: "The unifiedpush-operator is down. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
+          description: "The UnifiedPush Operator has been down for more than 5 minutes. "
+          summary: "The UnifiedPush Operator is down. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
           sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc"
       - alert: UnifiedpushPodcount
         annotations:
-          description: The Pod count for the unifiedpush has changed in the last 5 minutes.
-          summary: Pod count for namespace unifiedpush is {{ printf "%.0f" $value }}. Expected 3 pods. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
+          description: "The Pod count for the UnifiedPush has changed in the last 5 minutes."
+          summary: "Pod count for namespace UnifiedPush is {{ printf '%.0f' $value }}. Expected 3 pods. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
           sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc"
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="unifiedpush"})) or sum(kube_pod_status_ready{condition="true", namespace="unifiedpush"}) != 3

--- a/deploy/monitor/push_prometheus_rule.yaml
+++ b/deploy/monitor/push_prometheus_rule.yaml
@@ -1,0 +1,156 @@
+# Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: middleware
+    prometheus: application-monitoring
+    role: alert-rules
+  name: unifiedpush
+spec:
+  selector:
+    matchLabels:
+      app: unifiedpush
+  groups:
+    - name: general.rules
+      rules:
+      - alert: UnifiedpushDown
+        expr: absent(kube_pod_container_status_running{namespace="unifiedpush",container="ups"}==1)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: "The UnifiedPush Pod Server has been down for more than 5 minutes. "
+          summary: "The UnifiedPush Pod Server is down. For more information see on the UnifiedPush at https://github.com/aerogear/aerogear-unifiedpush-server"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushConsoleDown
+        expr: absent(kube_endpoint_address_available{endpoint="example-unifiedpushserver-unifiedpush"} == 1)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: "The UnifiedPush admin console has been down for more than 5 minutes. "
+          summary: "The UnifiedPush admin console endpoint has been unavailable for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushDatabaseDown
+        expr: absent(kube_pod_container_status_running{namespace="unifiedpush",container="postgresql"}==1)
+        for: 5m
+        labels: 
+          severity: critical
+        annotations:
+          description: "The UnifiedPush Database pod has been down for more than 5 minutes"
+          summary: "The UnifiedPush Database is down. For more information see on the UnifiedPush at https://github.com/aerogear/aerogear-unifiedpush-serve"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushPodCPUHigh # todo check if it will work after expse the metrcis
+        expr: "(rate(process_cpu_seconds_total{job='example-unifiedpushserver-unifiedpush'}[1m])) > (((kube_pod_container_resource_limits_cpu_cores{namespace='mobile-security-service',container='application'})/100)*90)"
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: "The UnifiedPush Server Pod has been at 90% CPU usage for more than 5 minutes"
+          summary: "The UnifiedPush Server Pod is reporting high cpu usage for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushPodMemoryHigh # todo check if it will work after expse the metrcis
+        expr: "(process_resident_memory_bytes{job='example-unifiedpushserver-unifiedpush'}) > (((kube_pod_container_resource_limits_memory_bytes{namespace='unifiedpush',container='ups'})/100)*90)"
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: "The UnifiedPush API has been at 90% memory usage for more than 5 minutes"
+          summary: "The UnifiedPush API is reporting high memory usage for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushApiHighRequestDuration # todo expose metric
+        expr: "api_requests_duration_seconds{job='example-unifiedpushserver-unifiedpush', quantile='0.5'} > 30"
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: "The UnifiedPush API has had http requests latency longer that 30 seconds for more than 5 minutes"
+          summary: "The UnifiedPush API is reporting high request latency for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushApiHighRequestHighConcurrentRequests # todo expose metric
+        expr: "api_requests_in_flight{job='example-unifiedpushserver-unifiedpush'} > 50"
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: "The UnifiedPush API has had 50 concurrent requests for more than 5 minutes"
+          summary: "The UnifiedPush API is reporting high request concurrency for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushApHighRequestFailure # todo expose metric
+        expr: "rate(api_requests_failure_total{job='example-unifiedpushserver-unifiedpush'}[1h])>10"
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          description: "The UnifiedPush API has reported more that 10 request failures in an hour"
+          summary: "The UnifiedPush API is reporting a high request failure over an hour. For more information see on the UnifiedPush ServerServer at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert:  UnifiedPushJavaHeapThresholdExceeded
+        expr: |
+          100 * jvm_memory_bytes_used{area="heap",namespace="unifiedpush"}
+            / jvm_memory_bytes_max{area="heap",namespace="unifiedpush"}
+            > 90
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          description: "The Heap Usage of the UnifiedPush Server exceeded 90% of usage"
+          summary: "The UnifiedPush Server JVM Heap Threshold Exceeded 90% of usage. For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushJavaHeapThresholdExceeded
+        expr: |
+          100 * jvm_memory_bytes_used{area="heap",namespace="unifiedpush"}
+            / jvm_memory_bytes_max{area="heap",namespace="unifiedpush"}
+            > 90
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          description: "The heap usage of the UnifiedPush Server exceeded 90% of usage"
+          summary: "The heap usage of the UnifiedPush Server exceeded 90% of usage. For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushJavaNonHeapThresholdExceeded
+        expr: |
+          100 * jvm_memory_bytes_used{area="nonheap",namespace="unifiedpush"}
+            / jvm_memory_bytes_max{area="nonheap",namespace="unifiedpush"}
+            > 90
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          description: "The nonheap usage of the UnifiedPush Server exceeded 90% of usage"
+          summary: "The nonheap usage of the UnifiedPush Server exceeded 90% of usage .For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushJavaGCTimePerMinuteScavenge
+        expr: |
+          increase(jvm_gc_collection_seconds_sum{gc="PS Scavenge",namespace="unifiedpush"}[1m]) > 1 * 60 * 0.9
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          description: "Amount of time per minute spent on garbage collection in the UnifiedPush Server pod exceeds 90%"
+          summary: "Amount of time per minute spent on garbage collection in the UnifiedPush Server pod exceeds 90%. This could indicate that the available heap memory is insufficient..For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushJavaDeadlockedThreads
+        expr: |
+          jvm_threads_deadlocked{namespace="unifiedpush"}
+            > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          description: "Number of threads in deadlock state of the UnifiedPush Server > 0"
+          summary: "Number of threads in deadlock state of the UnifiedPush Server > 0.For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+      - alert: UnifiedPushMessagesFailures # todo expose metric
+        expr: >
+          rate(ups_failed_msg_attempts{namespace="unifiedpush"}[5m])
+          * 300 > 50
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: "More than 50 failed messages attempts for UnifiedPush Server fails over the last 5 minutes."
+          summary: "More than 50 failed messages attempts for UnifiedPush Server fails over the last 5 minutes. For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo

--- a/deploy/monitor/push_service_monitor.yaml
+++ b/deploy/monitor/push_service_monitor.yaml
@@ -1,0 +1,14 @@
+# Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    monitoring-key: middleware
+  name: unifiedpush
+spec:
+  endpoints:
+    - path: /api/metrics
+      port: server
+  selector:
+    matchLabels:
+      app: unifiedpush


### PR DESCRIPTION
## Motivation
- https://issues.jboss.org/browse/INTLY-1441
- https://issues.jboss.org/browse/INTLY-1442

## What
- Add service monitor for the UPS Server
- Add prometheus rules and alerts
- Add apply/delete files in the monitor commands. 

## Why
- Started to attend the requirements based on the data that we have already and identify what is missing to expose by default. 

## Verification Steps
- Check here the alerts: https://prometheus-route-middleware-monitoring.apps.london-4bc4.openshiftworkshop.com/alerts

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [X] Finished task
- [ ] TODO


## Additional Notes

<img width="568" alt="Screenshot 2019-07-09 at 09 18 29" src="https://user-images.githubusercontent.com/7708031/60887355-8a0dd800-a22a-11e9-881c-5667c29c1db7.png">

NOTE: after we export the metrics for UPS Server we will do the task https://issues.jboss.org/browse/INTLY-2668 which was tracked to ensure that all alerts and metrics are working as planned and expected. 