### PR TITLE
verify the provided namespace before continuing to reconcile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ APP_NAMESPACES=unifiedpush-apps
 CODE_COMPILE_OUTPUT = build/_output/bin/unifiedpush-operator
 TEST_COMPILE_OUTPUT = build/_output/bin/unifiedpush-operator-test
 
+DEV_TAG ?= $(shell sh -c "git rev-parse --short HEAD")
+
 ##############################
 # Local Development          #
 ##############################
@@ -163,20 +165,10 @@ cluster/clean:
 	- kubectl delete namespace ${APP_NAMESPACES}
 
 
-.PHONY: image/build/master
-image/build/master:
-	operator-sdk build quay.io/${ORG_NAME}/${APP_NAME}:master
-
- .PHONY: image/push/master
-image/push/master:
-	docker push quay.io/${ORG_NAME}/${APP_NAME}:master
-
-
-
- .PHONY: image/build/dev
-image/build/dev:
+.PHONY: image/build
+image/build:
 	operator-sdk build quay.io/${ORG_NAME}/${APP_NAME}:${DEV_TAG}
 
- .PHONY: image/push/dev
-image/push/dev:
+.PHONY: image/push
+image/push:
 	docker push quay.io/${ORG_NAME}/${APP_NAME}:${DEV_TAG}

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TEST_PKGS = $(addprefix $(PKG)/,$(PACKAGES))
 APP_FILE=./cmd/manager/main.go
 
 NAMESPACE=unifiedpush
+APP_NAMESPACES=unifiedpush-apps
 CODE_COMPILE_OUTPUT = build/_output/bin/unifiedpush-operator
 TEST_COMPILE_OUTPUT = build/_output/bin/unifiedpush-operator-test
 
@@ -101,24 +102,48 @@ monitoring/uninstall:
 .PHONY: example-pushapplication/apply
 example-pushapplication/apply:
 	@echo ....... Applying the PushApplication example in the current namespace  ......
-	- kubectl apply -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml
+	- kubectl apply -n $(APP_NAMESPACES) -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml
 
 .PHONY: example-pushapplication/delete
 example-pushapplication/delete:
 	@echo ....... Deleting the PushApplication example in the current namespace  ......
-	- kubectl delete -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml
+	- kubectl delete -n $(APP_NAMESPACES) -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml
+
+.PHONY: android-variant/apply
+android-variant/apply:
+	make example-pushapplication/apply
+	@echo ....... Applying the Android Variant example in the current namespace  ......
+	- kubectl apply -n $(APP_NAMESPACES) -f deploy/crds/examples/push_v1alpha1_androidvariant_cr.yaml
+
+.PHONY: android-variant/delete
+android-variant/delete:
+	@echo ....... Applying the Android Variant example in the current namespace  ......
+	- kubectl delete -n $(APP_NAMESPACES) -f deploy/crds/examples/push_v1alpha1_androidvariant_cr.yaml
+
+
+.PHONY: ios-variant/apply
+ios-variant/apply:
+	make example-pushapplication/apply
+	@echo ....... Applying the Android Variant example in the current namespace  ......
+	- kubectl apply -n $(APP_NAMESPACES) -f deploy/crds/examples/push_v1alpha1_iosvariant_cr.yaml
+
+.PHONY: ios-variant/delete
+ios-variant/delete:
+	@echo ....... Applying the Android Variant example in the current namespace  ......
+	- kubectl delete -n $(APP_NAMESPACES) -f deploy/crds/examples/push_v1alpha1_iosvariant_cr.yaml
 
 .PHONY: cluster/prepare
 cluster/prepare:
 	- kubectl create namespace $(NAMESPACE)
 	- kubectl label namespace $(NAMESPACE) monitoring-key=middleware
+	- kubectl create namespace $(APP_NAMESPACES)
 	- kubectl create -n $(NAMESPACE) -f deploy/service_account.yaml
 	- kubectl create -n $(NAMESPACE) -f deploy/role.yaml
 	- kubectl create -n $(NAMESPACE) -f deploy/role_binding.yaml
-	- kubectl apply -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_pushapplication_crd.yaml
-	- kubectl apply -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_androidvariant_crd.yaml
-	- kubectl apply -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
-	- kubectl apply -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
+	- kubectl apply -f deploy/crds/push_v1alpha1_pushapplication_crd.yaml
+	- kubectl apply -f deploy/crds/push_v1alpha1_androidvariant_crd.yaml
+	- kubectl apply -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
+	- kubectl apply -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
 
 .PHONY: cluster/clean
 cluster/clean:
@@ -129,9 +154,29 @@ cluster/clean:
 	- kubectl delete -f deploy/role.yaml
 	- kubectl delete -n $(NAMESPACE) -f deploy/role_binding.yaml
 	- kubectl delete -n $(NAMESPACE) -f deploy/service_account.yaml
-	- kubectl delete -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_pushapplication_crd.yaml
-	- kubectl delete -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_androidvariant_crd.yaml
-	- kubectl delete -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
-	- kubectl delete -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
+	- kubectl delete -f deploy/crds/push_v1alpha1_pushapplication_crd.yaml
+	- kubectl delete -f deploy/crds/push_v1alpha1_androidvariant_crd.yaml
+	- kubectl delete -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
+	- kubectl delete -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
 	- make monitoring/uninstall
 	- kubectl delete namespace $(NAMESPACE)
+	- kubectl delete namespace ${APP_NAMESPACES}
+
+
+.PHONY: image/build/master
+image/build/master:
+	operator-sdk build quay.io/${ORG_NAME}/${APP_NAME}:master
+
+ .PHONY: image/push/master
+image/push/master:
+	docker push quay.io/${ORG_NAME}/${APP_NAME}:master
+
+
+
+ .PHONY: image/build/dev
+image/build/dev:
+	operator-sdk build quay.io/${ORG_NAME}/${APP_NAME}:${DEV_TAG}
+
+ .PHONY: image/push/dev
+image/push/dev:
+	docker push quay.io/${ORG_NAME}/${APP_NAME}:${DEV_TAG}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,9 +22,10 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
+            - name: APP_NAMESPACES
+              # Replace this with a comma (e.g. namespace,othernamespace) separated list of namespaces which the operator will action app crs
+              value: "unifiedpush-apps"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/pkg/controller/androidvariant/androidvariant_controller.go
+++ b/pkg/controller/androidvariant/androidvariant_controller.go
@@ -89,9 +89,10 @@ func (r *ReconcileAndroidVariant) Reconcile(request reconcile.Request) (reconcil
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	err = util.IsValidAppNamespace(instance.Namespace, operatorNamespace, instance.Name)
-	if err != nil {
-		return reconcile.Result{}, err
+	is := util.IsValidAppNamespace(instance.Namespace, operatorNamespace, instance.Name)
+	if !is {
+		reqLogger.Info("The app cr %s was created in a namespace which is not present in the APP_NAMESPACES environment variable provided to the operator or is not the in the operator namespace", instance.Name)
+		return reconcile.Result{}, nil
 	}
 
 	// Get a UPS Client for interactions with the UPS service

--- a/pkg/controller/androidvariant/androidvariant_controller.go
+++ b/pkg/controller/androidvariant/androidvariant_controller.go
@@ -6,6 +6,7 @@ import (
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	"github.com/aerogear/unifiedpush-operator/pkg/controller/util"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -80,6 +81,16 @@ func (r *ReconcileAndroidVariant) Reconcile(request reconcile.Request) (reconcil
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Check if the namespace of the cr is in the APP_NAMESPACES environment variable provided to the operator or if it's in the operator namespace
+	operatorNamespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	err = util.IsValidAppNamespace(instance.Namespace, operatorNamespace, instance.Name)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/iosvariant/iosvariant_controller.go
+++ b/pkg/controller/iosvariant/iosvariant_controller.go
@@ -7,6 +7,7 @@ import (
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	"github.com/aerogear/unifiedpush-operator/pkg/controller/util"
 
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,6 +83,16 @@ func (r *ReconcileIOSVariant) Reconcile(request reconcile.Request) (reconcile.Re
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Check if the namespace of the cr is in the APP_NAMESPACES environment variable provided to the operator or if it's in the operator namespace
+	operatorNamespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	err = util.IsValidAppNamespace(instance.Namespace, operatorNamespace, instance.Name)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/iosvariant/iosvariant_controller.go
+++ b/pkg/controller/iosvariant/iosvariant_controller.go
@@ -91,9 +91,10 @@ func (r *ReconcileIOSVariant) Reconcile(request reconcile.Request) (reconcile.Re
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	err = util.IsValidAppNamespace(instance.Namespace, operatorNamespace, instance.Name)
-	if err != nil {
-		return reconcile.Result{}, err
+	is := util.IsValidAppNamespace(instance.Namespace, operatorNamespace, instance.Name)
+	if !is {
+		reqLogger.Info("The app cr %s was created in a namespace which is not present in the APP_NAMESPACES environment variable provided to the operator or is not the in the operator namespace", instance.Name)
+		return reconcile.Result{}, nil
 	}
 
 	// Get a UPS Client for interactions with the UPS service

--- a/pkg/controller/pushapplication/pushapplication_controller.go
+++ b/pkg/controller/pushapplication/pushapplication_controller.go
@@ -87,9 +87,10 @@ func (r *ReconcilePushApplication) Reconcile(request reconcile.Request) (reconci
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	err = util.IsValidAppNamespace(instance.Namespace, operatorNamespace, instance.Name)
-	if err != nil {
-		return reconcile.Result{}, err
+	is := util.IsValidAppNamespace(instance.Namespace, operatorNamespace, instance.Name)
+	if !is {
+		reqLogger.Info("The app cr %s was created in a namespace which is not present in the APP_NAMESPACES environment variable provided to the operator or is not the in the operator namespace", instance.Name)
+		return reconcile.Result{}, nil
 	}
 
 	// Get a UPS Client for interactions with the UPS service

--- a/pkg/controller/pushapplication/pushapplication_controller.go
+++ b/pkg/controller/pushapplication/pushapplication_controller.go
@@ -6,6 +6,7 @@ import (
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	"github.com/aerogear/unifiedpush-operator/pkg/controller/util"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,6 +79,16 @@ func (r *ReconcilePushApplication) Reconcile(request reconcile.Request) (reconci
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Check if the namespace of the cr is in the APP_NAMESPACES environment variable provided to the operator or if it's in the operator namespace
+	operatorNamespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	err = util.IsValidAppNamespace(instance.Namespace, operatorNamespace, instance.Name)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/util/helpers.go
+++ b/pkg/controller/util/helpers.go
@@ -1,27 +1,25 @@
 package util
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
 
 // IsValidAppNamespace returns an error when the namespace passed is not present in the APP_NAMESPACES environment variable provided to the operator.
-func IsValidAppNamespace(crnamespace string, operatorNamespace string, name string) error {
+func IsValidAppNamespace(crnamespace string, operatorNamespace string, name string) bool {
 	appNamespacesEnvVar, found := os.LookupEnv("APP_NAMESPACES")
 	if !found {
-		return fmt.Errorf("APP_NAMESPACES environment variable is required for the creation of the app cr")
+		return false
 	}
 
 	if operatorNamespace == crnamespace {
-		return nil
+		return true
 	}
 
 	for _, ns := range strings.Split(appNamespacesEnvVar, ",") {
 		if ns == crnamespace {
-			return nil
+			return true
 		}
 	}
-
-	return fmt.Errorf("The app cr %s was created in a namespace which is not present in the APP_NAMESPACES environment variable provided to the operator", name)
+	return false
 }

--- a/pkg/controller/util/helpers.go
+++ b/pkg/controller/util/helpers.go
@@ -6,18 +6,18 @@ import (
 )
 
 // IsValidAppNamespace returns an error when the namespace passed is not present in the APP_NAMESPACES environment variable provided to the operator.
-func IsValidAppNamespace(crnamespace string, operatorNamespace string, name string) bool {
+func IsValidAppNamespace(crNamespace string, operatorNamespace string, name string) bool {
 	appNamespacesEnvVar, found := os.LookupEnv("APP_NAMESPACES")
 	if !found {
 		return false
 	}
 
-	if operatorNamespace == crnamespace {
+	if operatorNamespace == crNamespace {
 		return true
 	}
 
 	for _, ns := range strings.Split(appNamespacesEnvVar, ",") {
-		if ns == crnamespace {
+		if ns == crNamespace {
 			return true
 		}
 	}

--- a/pkg/controller/util/helpers.go
+++ b/pkg/controller/util/helpers.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// IsValidAppNamespace returns an error when the namespace passed is not present in the APP_NAMESPACES environment variable provided to the operator.
+func IsValidAppNamespace(crnamespace string, operatorNamespace string, name string) error {
+	appNamespacesEnvVar, found := os.LookupEnv("APP_NAMESPACES")
+	if !found {
+		return fmt.Errorf("APP_NAMESPACES environment variable is required for the creation of the app cr")
+	}
+
+	if operatorNamespace == crnamespace {
+		return nil
+	}
+
+	for _, ns := range strings.Split(appNamespacesEnvVar, ",") {
+		if ns == crnamespace {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("The app cr %s was created in a namespace which is not present in the APP_NAMESPACES environment variable provided to the operator", name)
+}


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9568

## Image
`quay.io/aerogear/unifiedpush-operator:f144d9e`

## What
Only respond to consumption crs which are created in a namespace which exists in a user specified list or in the oeprator namespace

## How
Check that the namespace is in the ENV VAR - APP_NAMESPACES or it is the operator namespace before moving on with the reconcile

## Verification Steps
`make cluster/clean`
`make install`
Wait for ups to come up

**Verify operator namespace**
_Steps_
kubectl apply -n unifiedpush -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml 
_Expected result_
Application is created in ups console
_Cleanup_
kubectl delete -n unifiedpush -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml 

**Verify APP_NAMESPACES namespace**
_Steps_
kubectl apply -n unifiedpush-apps -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml 
_Expected result_
Application is created in ups console
_Cleanup_
kubectl delete -n unifiedpush-apps -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml 

**Verify neither of the above namespace**
_Steps_
oc new-project test-ups
kubectl apply -n test-ups -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml 
_Expected result_
Application is **not created** in ups console
_Cleanup_
kubectl delete -n test-ups -f deploy/crds/examples/push_v1alpha1_pushapplication_cr.yaml 
oc delete project ups-test

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

