### PR TITLE
[INTLY-1443] and [INTLY-2668] - Push Grafana dash + alerts + sop

### DIFF
--- a/SOP/SOP-operator.adoc
+++ b/SOP/SOP-operator.adoc
@@ -44,16 +44,14 @@ The following guide outlines the steps required to resolve issues with the Prome
 NOTE: The operator is responsible to manage and create all objects required in order to have the UnifiedPush Service and its database provided in the cluster.
 . Check its logs by running `oc logs <operator-podname>`
 +
-NOTE: You can save the logs by running `oc logs <operator-podname> > <filename>.log`. The logs may provide to you useful information to lead you the root cause as it is a required information for its maintainers are able to help you with.
-+
-TIP: May will be required re-install the project or just the link:./deploy/operator.yaml[operator.yaml] file if all kinds of CR and CRD's are applied in the namespace.
+NOTE: You can save the logs by running `oc logs <operator-podname> > <filename>.log`. The logs may provide you with useful information to lead you to the root cause, and they are also useful for providing to the project maintainers when you create an issue.
 
 == Warning
 
 === UnifiedPushPodCount
 
 . Switch to the UnifiedPush namespace by running `oc project <namespace>`. E.g `oc project unifiedpush`.
-. Check if it has at least 3 pods (Service, Database and Operator) by running `oc get pods`.Following an example of the expected result.
+. Check if it has at least 3 pods (Service, Database and Operator) by running `oc get pods`. The following is an example of the expected result:
 +
 [source,shell]
 ----

--- a/SOP/SOP-operator.adoc
+++ b/SOP/SOP-operator.adoc
@@ -16,18 +16,66 @@ endif::[]
 :toc:
 toc::[]
 
-== UnifiedPushOperatorDown
+== Overview
 
-. Switch to the UnifiedPush namespace by running `oc project unifiedpush`
-. Check if the operator pod to is present by running `oc get pods | grep operator`
+The following guide outlines the steps required to manage and solve issues in the https://github.com/aerogear/unifiedpush-operator[UnifiedPush Operator].
+
+== Reference Articles
+
+- https://github.com/aerogear/unifiedpush-operator[UnifiedPush Operator]
+- https://prometheus.io/docs/practices/alerting/[Prometheus Alerts documentation]
+- https://github.com/operator-framework[operator-framework]
+
+== Success Indicators
+
+All alerts should appear as green in the Prometheus Alert Monitoring.
+
+== Prometheus Alerts Procedures
+
+The following guide outlines the steps required to resolve issues with the Prometheus alerts configured to monitor the https://github.com/aerogear/unifiedpush-operator[UnifiedPush Operator]. The alerts are configured by enabling the https://github.com/aerogear/unifiedpush-operator#monitoring-service-metrics[Monitoring Service (Metrics)] for this project.
+
+== Critical
+
+=== UnifiedPushOperatorDown
+
+. Switch to the UnifiedPush namespace by running `oc project <namespace>`. E.g `oc project unifiedpush`.
+. Follow the <<Validate>> steps.
++
+NOTE: The operator is responsible to manage and create all objects required in order to have the UnifiedPush Service and its database provided in the cluster.
 . Check its logs by running `oc logs <operator-podname>`
 +
-NOTE: You can save the logs by running `oc logs <operator-podname> > <filename>.log`
-. If the operator pod is not preset check its installation. May will be required re-install the project or just the link:./deploy/operator.yaml[operator.yaml] file.
+NOTE: You can save the logs by running `oc logs <operator-podname> > <filename>.log`. The logs may provide to you useful information to lead you the root cause as it is a required information for its maintainers are able to help you with.
++
+TIP: May will be required re-install the project or just the link:./deploy/operator.yaml[operator.yaml] file if all kinds of CR and CRD's are applied in the namespace.
 
-== UnifiedPushPodcount
+== Warning
 
-. Switch to the UnifiedPush namespace by running `oc project unifiedpush`
-. Check if it has at least 3 pods (Service, Database and Operator) by running `oc get pods`.
+=== UnifiedPushPodCount
 
-NOTE: The operator should  maintain the number of pods running for the UnifiedPush Server and its Database.
+. Switch to the UnifiedPush namespace by running `oc project <namespace>`. E.g `oc project unifiedpush`.
+. Check if it has at least 3 pods (Service, Database and Operator) by running `oc get pods`.Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get pods
+NAME                                           READY     STATUS    RESTARTS   AGE
+example-unifiedpushserver-1-dk8vm              2/2       Running   2          9d
+example-unifiedpushserver-postgresql-1-bw8mt   1/1       Running   1          9d
+unifiedpush-operator-58c8877fd8-g6dvr          1/1       Running   3          9d
+----
++
+NOTE: The operator will keep the number of replicas specified in the DeploymentConfigs for the UnifiedPush Server and its Database in sync with what's specified in the UnifiedPushServer CR.
+
+== Validate
+
+. Check if the operator pod to is present by running `oc get pods | grep operator`. Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get pods | grep operator
+unifiedpush-operator-58c8877fd8-g6dvr          1/1       Running   3          9d
+----
+
+== Monitoring
+
+If the https://github.com/aerogear/unifiedpush-operator#monitoring-service-metrics[Monitoring Service (Metrics)] is enabled for your installation you are able to check its Grafana Dashboard, `UnifiedPush Operator`, and the Prometheus Monitoring instance used for it.

--- a/SOP/SOP-push.adoc
+++ b/SOP/SOP-push.adoc
@@ -468,20 +468,6 @@ NOTE: You can save the logs by running `oc logs <database-podname> > <filename>.
 .. Check if the Database image was pulled successfully.
 . Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc[UnifiedPushOperatorDown]
 
-==== UnifiedPushApiHighRequestFailure
-
-It means that Service pod(s) are facing performance issues.
-
-. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
-. Following the steps <<To scale the pod>> in order to try to solve performance issues.
-
-==== UnifiedPushPodCPUHigh
-
-It means that Service pod(s) are using more CPU than expected.
-
-. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
-. Following the steps <<To scale the pod>> in order to try to solve performance issues.
-
 ==== UnifiedPushJavaHeapThresholdExceeded
 
 It means that Service pod(s) are facing performance issues.
@@ -510,36 +496,6 @@ It means that Service pod(s) are facing performance issues.
 It means that Service pod(s) has some error that is not able to send the quantity of messages expected.
 
 . Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
-
-==== UnifiedPushPodMemoryHigh
-
-It means that Service pod(s) are facing performance issues.
-
-. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
-. Following the steps <<To scale the pod>> in order to try to solve performance issues.
-
-==== UnifiedPushApiHighRequestDuration
-
-It means that the requests performed to the UPS Service are taking too long.
-
-. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
-. Following the steps <<To scale the pod>> in order to try to solve performance issues.
-
-==== UnifiedPushApiHighConcurrentRequests
-
-It means that are to many requests to the UPS Service falling.
-
-. Please following the <<To capture the logs>> procedure before in order to capture the logs and send it to its maintainers.
-
-TIP: May delete the UPS Deployment could allow the operator re-create it with the correct configuration.
-
-==== UnifiedPushJavaDeadlockedThreads,
-
-It means that are threads locked in the UPS Service.
-
-. Please following the <<To capture the logs>> procedure before in order to capture the logs and send it to its maintainers.
-
-TIP: May delete the UPS Deployment could allow the operator re-create it with the correct configuration.
 
 === To capture the logs
 

--- a/SOP/SOP-push.adoc
+++ b/SOP/SOP-push.adoc
@@ -16,41 +16,446 @@ endif::[]
 :toc:
 toc::[]
 
-== Critical
+== Overview
 
-=== UnifiedpushDown or UnifiedPushConsoleDown
+The following guide outlines the steps required to manage and solve issues over the https://github.com/aerogear/aerogear-unifiedpush-server[UnifiedPush Server] managed, installed and configured via the https://github.com/aerogear/unifiedpush-operator[UnifiedPush Operator].
 
-. Check that the UnifiedPushServer CR is deployed in the same namespace as the operator by running `oc get UnifiedPushServer`
+== Reference Articles
+
+- https://github.com/aerogear/aerogear-unifiedpush-server[UnifiedPush Server]
+- https://github.com/aerogear/unifiedpush-operator[UnifiedPush Operator]
+- https://prometheus.io/docs/practices/alerting/[Prometheus Alerts documentation]
+
+== Success Indicators
+
+All alerts should appears as green in the Prometheus Alert Monitoring.
+
+== Prometheus Alerts Procedures
+
+The following guide outlines the steps required to solve issues which will be alert by the Prometheus alerts configured to monitoring the  https://github.com/aerogear/aerogear-unifiedpush-server[UnifiedPush Server] when it is managed, installed and configured via the https://github.com/aerogear/unifiedpush-operator[UnifiedPush Operator].
+
+IMPORTANT: Before check any following steps see if the operator pod is running successfully. More info: https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc[UnifiedPushOperatorDown]
+
+TIP: You can save the logs by running `oc logs <podname> > <filename>.log`. The logs can provided to you useful information in order to identify the root cause of the issue as they are required information to be send to its maintainers in the case it need to be checked by them.
+
+=== Critical
+
+==== UnifiedPushDown or UnifiedPushConsoleDown
+
+The pod which runs the https://github.com/aerogear/aerogear-unifiedpush-server[UnifiedPush Server] is down or is not present in the same namespace of the operator.
+
+. Check that the link:./deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml[UnifiedPushServer CR] or link:./deploy/crds/push_v1alpha1_unifiedpushserver_cr_with_backup[UnifiedPushServerWithBackup CR] is deployed in the same namespace as the operator by running `oc get UnifiedPushServer`. Following the expected result.
++
+NOTE: Just one kind of UnifiedPushServer CR can be applied, however, if the backup service is enable for your installation then it means that it is using the ink:./deploy/crds/push_v1alpha1_unifiedpushserver_cr_with_backup[UnifiedPushServerWithBackup CR].
++
+[source,shell]
+----
+$ oc get UnifiedPushServer
+NAME                        AGE
+example-unifiedpushserver   9d
+----
++
+NOTE: The UnifiedPushServer should be applied in the same namespace of the operator. The operator will not able to manage it in another namespace.
++
 . Check the environment variables of the Server
 .. Run `oc describe pods -l service=ups`
-.. For further information see https://github.com/aerogear/aerogear-unifiedpush-server#container-configuration.
 +
-Note: It will use the values mapped in the Secret created by the operator with the database pod name.
+NOTE: For further information see https://github.com/aerogear/aerogear-unifiedpush-server#container-configuration.
++
+WARNING: It will use the values mapped in the Secret created by the operator with the database pod name.
 +
 . Check the environment variables of the Database
-.. Run `oc get pods` and check the database pod name
-.. Run `oc describe pods <databasepodname>`
+.. Run `oc get pods` and check the database pod name. Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get pods
+NAME                                           READY     STATUS    RESTARTS   AGE
+example-unifiedpushserver-1-dk8vm              2/2       Running   2          9d
+example-unifiedpushserver-postgresql-1-bw8mt   1/1       Running   1          9d
+unifiedpush-operator-58c8877fd8-g6dvr          1/1       Running   3          9d
+----
++
+.. Run `oc describe pods <databasepodname>`. Following an example of the expected result.
++
+[source,shell]
+----
+ $ oc describe pods example-unifiedpushserver-postgresql-1-bw8mt
+Name:               example-unifiedpushserver-postgresql-1-bw8mt
+Namespace:          unifiedpush
+Priority:           0
+PriorityClassName:  <none>
+Node:               localhost/192.168.64.27
+Start Time:         Wed, 03 Jul 2019 21:45:02 -0300
+Labels:             app=example-unifiedpushserver
+                    deployment=example-unifiedpushserver-postgresql-1
+                    deploymentconfig=example-unifiedpushserver-postgresql
+                    service=example-unifiedpushserver-postgresql
+Annotations:        openshift.io/deployment-config.latest-version=1
+                    openshift.io/deployment-config.name=example-unifiedpushserver-postgresql
+                    openshift.io/deployment.name=example-unifiedpushserver-postgresql-1
+                    openshift.io/scc=restricted
+Status:             Running
+IP:                 172.17.0.13
+Controlled By:      ReplicationController/example-unifiedpushserver-postgresql-1
+Containers:
+  postgresql:
+    Container ID:   docker://16f6f7ea2ac25f72d308d4e89662dc5f4ccd1935db51374aedaed64edd104934
+    Image:          172.30.1.1:5000/openshift/postgresql@sha256:0c78f036478b50800913056c564147ec452214fd0b6d41f4eec4fb3b5c63d246
+    Image ID:       docker-pullable://172.30.1.1:5000/openshift/postgresql@sha256:0c78f036478b50800913056c564147ec452214fd0b6d41f4eec4fb3b5c63d246
+    Port:           5432/TCP
+    Host Port:      0/TCP
+    State:          Running
+      Started:      Fri, 12 Jul 2019 08:51:38 -0300
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    255
+      Started:      Wed, 03 Jul 2019 21:45:05 -0300
+      Finished:     Fri, 12 Jul 2019 08:48:00 -0300
+    Ready:          True
+    Restart Count:  1
+    Limits:
+      memory:  512Mi
+    Requests:
+      memory:   512Mi
+    Liveness:   tcp-socket :5432 delay=0s timeout=1s period=10s #success=1 #failure=3
+    Readiness:  exec [/bin/sh -i -c psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'] delay=5s timeout=1s period=10s #success=1 #failure=3
+    Environment:
+      POSTGRESQL_USER:      <set to the key 'POSTGRES_USERNAME' in secret 'example-unifiedpushserver-postgresql'>  Optional: false
+      POSTGRESQL_PASSWORD:  <set to the key 'POSTGRES_PASSWORD' in secret 'example-unifiedpushserver-postgresql'>  Optional: false
+      POSTGRESQL_DATABASE:  <set to the key 'POSTGRES_DATABASE' in secret 'example-unifiedpushserver-postgresql'>  Optional: false
+    Mounts:
+      /var/lib/pgsql/data from example-unifiedpushserver-postgresql-data (rw)
+      /var/run/secrets/kubernetes.io/serviceaccount from default-token-hkwgz (ro)
+Conditions:
+  Type              Status
+  Initialized       True
+  Ready             True
+  ContainersReady   True
+  PodScheduled      True
+Volumes:
+  example-unifiedpushserver-postgresql-data:
+    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
+    ClaimName:  example-unifiedpushserver-postgresql
+    ReadOnly:   false
+  default-token-hkwgz:
+    Type:        Secret (a volume populated by a Secret)
+    SecretName:  default-token-hkwgz
+    Optional:    false
+QoS Class:       Burstable
+Node-Selectors:  <none>
+Tolerations:     node.kubernetes.io/memory-pressure:NoSchedule
+Events:          <none>
+----
++
+NOTE: It can lead you to find the root cause of the issue faced.
++
 .. Check if the database image was pulled successfully.
 . Check the logs of the UPS OAuth Proxy Container
-.. Get the service pod name -> `oc describe pods -l service=ups`
-.. Run `oc logs <service-podname> -c ups-oauth-proxy`
-.. Save the logs by running `oc logs <service-podname> -c ups-oauth-proxy > <filename>.log`
-.. Check if the oauth-proxy image was pulled successfully
+.. Get the service pod name -> `oc describe pods -l service=ups`. Following an example of the expected result.
++
+[source,shell]
+----
+$ oc describe pods -l service=ups
+Name:               example-unifiedpushserver-1-dk8vm
+Namespace:          unifiedpush
+Priority:           0
+PriorityClassName:  <none>
+Node:               localhost/192.168.64.27
+Start Time:         Wed, 03 Jul 2019 21:45:05 -0300
+Labels:             app=example-unifiedpushserver
+                    deployment=example-unifiedpushserver-1
+                    deploymentconfig=example-unifiedpushserver
+                    service=ups
+Annotations:        openshift.io/deployment-config.latest-version=1
+                    openshift.io/deployment-config.name=example-unifiedpushserver
+                    openshift.io/deployment.name=example-unifiedpushserver-1
+                    openshift.io/scc=restricted
+Status:             Running
+IP:                 172.17.0.4
+Controlled By:      ReplicationController/example-unifiedpushserver-1
+Init Containers:
+  postgresql:
+    Container ID:  docker://ba7061aa4b115367eb4e9354aec327162dca6f181dd11b36632e15d273e3037d
+    Image:         172.30.1.1:5000/openshift/postgresql@sha256:0c78f036478b50800913056c564147ec452214fd0b6d41f4eec4fb3b5c63d246
+    Image ID:      docker-pullable://172.30.1.1:5000/openshift/postgresql@sha256:0c78f036478b50800913056c564147ec452214fd0b6d41f4eec4fb3b5c63d246
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      /bin/sh
+      -c
+      source /opt/rh/rh-postgresql96/enable && until pg_isready -h $POSTGRES_SERVICE_HOST; do echo waiting for database; sleep 2; done;
+    State:          Terminated
+      Reason:       Completed
+      Exit Code:    0
+      Started:      Fri, 12 Jul 2019 08:51:28 -0300
+      Finished:     Fri, 12 Jul 2019 08:51:53 -0300
+    Ready:          True
+    Restart Count:  0
+    Environment:
+      POSTGRES_SERVICE_HOST:  example-unifiedpushserver-postgresql
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from example-unifiedpushserver-token-5cmlp (ro)
+Containers:
+  ups:
+    Container ID:   docker://28fc71000c66d9223ab6e340a030491c4348a0b51979237de04488fe18282337
+    Image:          docker.io/aerogear/unifiedpush-wildfly-plain@sha256:62ecab1e74e3b1a7b2ef1d9eb7594f29bcf6b55702c269c9deebdadf8aea8a8a
+    Image ID:       docker-pullable://docker.io/aerogear/unifiedpush-wildfly-plain@sha256:62ecab1e74e3b1a7b2ef1d9eb7594f29bcf6b55702c269c9deebdadf8aea8a8a
+    Port:           8080/TCP
+    Host Port:      0/TCP
+    State:          Running
+      Started:      Fri, 12 Jul 2019 08:51:57 -0300
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    255
+      Started:      Wed, 03 Jul 2019 21:45:20 -0300
+      Finished:     Fri, 12 Jul 2019 08:48:01 -0300
+    Ready:          True
+    Restart Count:  1
+    Liveness:       http-get http://:8080/rest/applications delay=60s timeout=2s period=10s #success=1 #failure=3
+    Readiness:      http-get http://:8080/rest/applications delay=15s timeout=2s period=10s #success=1 #failure=3
+    Environment:
+      POSTGRES_SERVICE_HOST:  example-unifiedpushserver-postgresql
+      POSTGRES_SERVICE_PORT:  5432
+      POSTGRES_USER:          <set to the key 'POSTGRES_USERNAME' in secret 'example-unifiedpushserver-postgresql'>  Optional: false
+      POSTGRES_PASSWORD:      <set to the key 'POSTGRES_PASSWORD' in secret 'example-unifiedpushserver-postgresql'>  Optional: false
+      POSTGRES_DATABASE:      <set to the key 'POSTGRES_DATABASE' in secret 'example-unifiedpushserver-postgresql'>  Optional: false
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from example-unifiedpushserver-token-5cmlp (ro)
+  ups-oauth-proxy:
+    Container ID:  docker://05f0d609bc3c9a2273db9b88a13cc26e4504e1bfed125e7c7dad59ba8a6c6712
+    Image:         docker.io/openshift/oauth-proxy@sha256:731c1fdad1de4bf68ae9eece5e99519f063fd8d9990da312082b4c995c4e4e33
+    Image ID:      docker-pullable://docker.io/openshift/oauth-proxy@sha256:731c1fdad1de4bf68ae9eece5e99519f063fd8d9990da312082b4c995c4e4e33
+    Port:          4180/TCP
+    Host Port:     0/TCP
+    Args:
+      --provider=openshift
+      --openshift-service-account=example-unifiedpushserver
+      --upstream=http://localhost:8080
+      --http-address=0.0.0.0:4180
+      --skip-auth-regex=/rest/sender,/rest/registry/device,/rest/prometheus/metrics,/rest/auth/config
+      --https-address=
+      --cookie-secret=b3207b16503d491993e2057b9959951a
+    State:          Running
+      Started:      Fri, 12 Jul 2019 08:52:01 -0300
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    255
+      Started:      Wed, 03 Jul 2019 21:45:23 -0300
+      Finished:     Fri, 12 Jul 2019 08:48:01 -0300
+    Ready:          True
+    Restart Count:  1
+    Environment:    <none>
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from example-unifiedpushserver-token-5cmlp (ro)
+Conditions:
+  Type              Status
+  Initialized       True
+  Ready             True
+  ContainersReady   True
+  PodScheduled      True
+Volumes:
+  example-unifiedpushserver-token-5cmlp:
+    Type:        Secret (a volume populated by a Secret)
+    SecretName:  example-unifiedpushserver-token-5cmlp
+    Optional:    false
+QoS Class:       BestEffort
+Node-Selectors:  <none>
+Tolerations:     <none>
+Events:          <none>
+----
++
+NOTE: It can lead you to find the root cause of the issue faced.
++
+.. Run `oc logs <service-podname> -c ups-oauth-proxy`. E.g `oc logs example-unifiedpushserver-1-dk8vm -c ups-oauth-proxy`
++
+NOTE: Usually it has no logs at all, however, it can lead you to find the root cause of the issue faced.
++
+.. If logs are found in the above step then save the logs by running `oc logs <service-podname> -c ups-oauth-proxy > <filename>.log`
++
+NOTE: Capture the logs are important to provide the required information for its maintainers in order to allow them check it.
++
+.. Check if the oauth-proxy image was pulled successfully.
 . Check the logs of the UPS Container
-.. Get the service pod name -> `oc describe pods -l service=ups`
-.. Save the logs by running `oc logs <service-podname> -c ups > <filename>.log`
-.. See the `pod/example-unifiedpushserver-<xyz123>` logs.
+.. Get the service pod name -> `oc describe pods -l service=ups`. Following an example of the expected result.
++
+[source,shell]
+----
+$ oc describe pods -l service=ups
+Name:               example-unifiedpushserver-1-dk8vm
+Namespace:          unifiedpush
+Priority:           0
+PriorityClassName:  <none>
+Node:               localhost/192.168.64.27
+Start Time:         Wed, 03 Jul 2019 21:45:05 -0300
+Labels:             app=example-unifiedpushserver
+                    deployment=example-unifiedpushserver-1
+                    deploymentconfig=example-unifiedpushserver
+                    service=ups
+Annotations:        openshift.io/deployment-config.latest-version=1
+                    openshift.io/deployment-config.name=example-unifiedpushserver
+                    openshift.io/deployment.name=example-unifiedpushserver-1
+                    openshift.io/scc=restricted
+Status:             Running
+IP:                 172.17.0.4
+Controlled By:      ReplicationController/example-unifiedpushserver-1
+Init Containers:
+  postgresql:
+    Container ID:  docker://ba7061aa4b115367eb4e9354aec327162dca6f181dd11b36632e15d273e3037d
+    Image:         172.30.1.1:5000/openshift/postgresql@sha256:0c78f036478b50800913056c564147ec452214fd0b6d41f4eec4fb3b5c63d246
+    Image ID:      docker-pullable://172.30.1.1:5000/openshift/postgresql@sha256:0c78f036478b50800913056c564147ec452214fd0b6d41f4eec4fb3b5c63d246
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      /bin/sh
+      -c
+      source /opt/rh/rh-postgresql96/enable && until pg_isready -h $POSTGRES_SERVICE_HOST; do echo waiting for database; sleep 2; done;
+    State:          Terminated
+      Reason:       Completed
+      Exit Code:    0
+      Started:      Fri, 12 Jul 2019 08:51:28 -0300
+      Finished:     Fri, 12 Jul 2019 08:51:53 -0300
+    Ready:          True
+    Restart Count:  0
+    Environment:
+      POSTGRES_SERVICE_HOST:  example-unifiedpushserver-postgresql
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from example-unifiedpushserver-token-5cmlp (ro)
+Containers:
+  ups:
+    Container ID:   docker://28fc71000c66d9223ab6e340a030491c4348a0b51979237de04488fe18282337
+    Image:          docker.io/aerogear/unifiedpush-wildfly-plain@sha256:62ecab1e74e3b1a7b2ef1d9eb7594f29bcf6b55702c269c9deebdadf8aea8a8a
+    Image ID:       docker-pullable://docker.io/aerogear/unifiedpush-wildfly-plain@sha256:62ecab1e74e3b1a7b2ef1d9eb7594f29bcf6b55702c269c9deebdadf8aea8a8a
+    Port:           8080/TCP
+    Host Port:      0/TCP
+    State:          Running
+      Started:      Fri, 12 Jul 2019 08:51:57 -0300
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    255
+      Started:      Wed, 03 Jul 2019 21:45:20 -0300
+      Finished:     Fri, 12 Jul 2019 08:48:01 -0300
+    Ready:          True
+    Restart Count:  1
+    Liveness:       http-get http://:8080/rest/applications delay=60s timeout=2s period=10s #success=1 #failure=3
+    Readiness:      http-get http://:8080/rest/applications delay=15s timeout=2s period=10s #success=1 #failure=3
+    Environment:
+      POSTGRES_SERVICE_HOST:  example-unifiedpushserver-postgresql
+      POSTGRES_SERVICE_PORT:  5432
+      POSTGRES_USER:          <set to the key 'POSTGRES_USERNAME' in secret 'example-unifiedpushserver-postgresql'>  Optional: false
+      POSTGRES_PASSWORD:      <set to the key 'POSTGRES_PASSWORD' in secret 'example-unifiedpushserver-postgresql'>  Optional: false
+      POSTGRES_DATABASE:      <set to the key 'POSTGRES_DATABASE' in secret 'example-unifiedpushserver-postgresql'>  Optional: false
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from example-unifiedpushserver-token-5cmlp (ro)
+  ups-oauth-proxy:
+    Container ID:  docker://05f0d609bc3c9a2273db9b88a13cc26e4504e1bfed125e7c7dad59ba8a6c6712
+    Image:         docker.io/openshift/oauth-proxy@sha256:731c1fdad1de4bf68ae9eece5e99519f063fd8d9990da312082b4c995c4e4e33
+    Image ID:      docker-pullable://docker.io/openshift/oauth-proxy@sha256:731c1fdad1de4bf68ae9eece5e99519f063fd8d9990da312082b4c995c4e4e33
+    Port:          4180/TCP
+    Host Port:     0/TCP
+    Args:
+      --provider=openshift
+      --openshift-service-account=example-unifiedpushserver
+      --upstream=http://localhost:8080
+      --http-address=0.0.0.0:4180
+      --skip-auth-regex=/rest/sender,/rest/registry/device,/rest/prometheus/metrics,/rest/auth/config
+      --https-address=
+      --cookie-secret=b3207b16503d491993e2057b9959951a
+    State:          Running
+      Started:      Fri, 12 Jul 2019 08:52:01 -0300
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    255
+      Started:      Wed, 03 Jul 2019 21:45:23 -0300
+      Finished:     Fri, 12 Jul 2019 08:48:01 -0300
+    Ready:          True
+    Restart Count:  1
+    Environment:    <none>
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from example-unifiedpushserver-token-5cmlp (ro)
+Conditions:
+  Type              Status
+  Initialized       True
+  Ready             True
+  ContainersReady   True
+  PodScheduled      True
+Volumes:
+  example-unifiedpushserver-token-5cmlp:
+    Type:        Secret (a volume populated by a Secret)
+    SecretName:  example-unifiedpushserver-token-5cmlp
+    Optional:    false
+QoS Class:       BestEffort
+Node-Selectors:  <none>
+Tolerations:     <none>
+Events:          <none>
+----
++
+NOTE: It can lead you to find the root cause of the issue faced.
++
+.. Save the logs by running `oc logs <service-podname> -c ups > <filename>.log`. E.g `oc logs example-unifiedpushserver-1-dk8vm -c ups > logs.log`
++
+NOTE: Capture the logs are important to provide the required information for its maintainers in order to allow them check it.
++
+.. See and capture the `pod/example-unifiedpushserver-<xyz123> > <filename>.log` logs. E.g `oc logs example-unifiedpushserver-1-dk8vm -c ups > logs.log`
++
+NOTE: May the logs can lead you to check the root cause of this issuse and capture the logs are important to provide the required information for its maintainers in order to allow them check it.
++
 .. Check if the UnifiedPush Server image was pulled successfully
 . Check if the secret was created
-.. Run `oc get secrets` in the namespace where the operator is installed
-. Check if the values in the secret are correct.
-.. Run `for field in POSTGRES_{DATABASE,HOST,USERNAME,PASSWORD,SUPERUSER,VERSION}; do printf "${field}: " && oc get secret <CR Name>-postgresql -o jsonpath="{.data.$field}" | base64 -d && echo; done`
+.. Run `oc get secrets | grep postgresql` in the namespace where the operator is installed. Following the expected result.
++
+[source,shell]
+----
+$ oc get secrets | grep postgresql
+example-unifiedpushserver-postgresql        Opaque                                6         9d
+----
++
+NOTE: The secret is required in order to provide the data required for the database pod container as user, database name and password.
++
+. Check if the values in the secret are correct. To check them you can use `oc edit secret <postgresqlsecretname>`. E.g `oc edit secret example-unifiedpushserver-postgresql`. Following an example of the expected result.
++
+[source,shell]
+----
+apiVersion: v1
+data:
+  POSTGRES_DATABASE: dW5pZmllZHB1c2g=
+  POSTGRES_HOST: ZXhhbXBsZS11bmlmaWVkcHVzaHNlcnZlci1wb3N0Z3Jlc3FsLnVuaWZpZWRwdXNoLnN2Yw==
+  POSTGRES_PASSWORD: NzM4NDQ1Mjg1Nzc2NDc4NmIxY2FmMjRlNjdkZDYyNzY=
+  POSTGRES_SUPERUSER: ZmFsc2U=
+  POSTGRES_USERNAME: dW5pZmllZHB1c2g=
+  POSTGRES_VERSION: MTA=
+kind: Secret
+...
+----
++
+NOTE: The values described above should not be the same but should all data keys shoud be present with each respective value.
++
 . Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc[UnifiedPushOperatorDown]
 
-=== UnifiedPushDatabaseDown
+==== UnifiedPushDatabaseDown
 
-. Check that the UnifiedPushServer CR is deployed in the same namespace as the operator by running `oc get UnifiedPushServer`
-. Check that the Database Pod is deployed in the same namespace as the operator by running `oc get pods | grep postgresql`
+The pod which runs the https://github.com/aerogear/aerogear-unifiedpush-server[UnifiedPush Server]'s Database(PostgreSQL) is down or is not present in the same namespace of the operator.
+
+. Check that the link:./deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml[UnifiedPushServer CR] or link:./deploy/crds/push_v1alpha1_unifiedpushserver_cr_with_backup[UnifiedPushServerWithBackup CR] is deployed in the same namespace as the operator by running `oc get UnifiedPushServer`. Following the expected result.
++
+NOTE: Just one kind of UnifiedPushServer CR can be applied, however, if the backup service is enable for your installation then it means that it is using the ink:./deploy/crds/push_v1alpha1_unifiedpushserver_cr_with_backup[UnifiedPushServerWithBackup CR].
++
+[source,shell]
+----
+$ oc get UnifiedPushServer
+NAME                        AGE
+example-unifiedpushserver   9d
+----
++
+NOTE: The 1 UnifiedPushServer CR (link:./deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml[UnifiedPushServer CR] or link:./deploy/crds/push_v1alpha1_unifiedpushserver_cr_with_backup[UnifiedPushServerWithBackup CR]) should be applied in the same namespace of the operator.
++
+. Check that the Database Pod is deployed in the same namespace as the operator by running `oc get pods | grep postgresql`. Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get pods | grep postgresql
+example-unifiedpushserver-postgresql-1-bw8mt   1/1       Running   1          9d
+----
 +
 NOTE: It will use the values mapped in the Secret created by the operator with the database pod name.
 +
@@ -59,61 +464,362 @@ NOTE: It will use the values mapped in the Secret created by the operator with t
 +
 NOTE: You can save the logs by running `oc logs <database-podname> > <filename>.log`
 +
-.. Check if the Database image was pulled successfully
+. Check if you are able to see any useful information in the logs which can lead you for the root cause of the issue. Also, by capturing the logs you are able to provide a required information for its maintainers if it be required.
+.. Check if the Database image was pulled successfully.
 . Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc[UnifiedPushOperatorDown]
 
-=== UnifiedPushApiHighRequestFailure
+==== UnifiedPushApiHighRequestFailure
 
-- Check <<General procedure>>
+It means that Service pod(s) are facing performance issues.
 
-=== UnifiedPushPodCPUHigh
+. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
+. Following the steps <<To scale the pod>> in order to try to solve performance issues.
 
-- Check <<General procedure>>
+==== UnifiedPushPodCPUHigh
 
-=== UnifiedPushJavaHeapThresholdExceeded
+It means that Service pod(s) are using more CPU than expected.
 
-- Check <<General procedure>>
+. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
+. Following the steps <<To scale the pod>> in order to try to solve performance issues.
 
-=== UnifiedPushJavaNonHeapThresholdExceeded
+==== UnifiedPushJavaHeapThresholdExceeded
 
-- Check <<General procedure>>
+It means that Service pod(s) are facing performance issues.
 
-=== UnifiedPushJavaGCTimePerMinuteScavenge
+. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
+. Following the steps <<To scale the pod>> in order to try to solve performance issues.
 
-- Check <<General procedure>>
+==== UnifiedPushJavaNonHeapThresholdExceeded
 
-== Warning
+It means that Service pod(s) are facing performance issues.
 
-=== UnifiedPushMessagesFailures
+. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
+. Following the steps <<To scale the pod>> in order to try to solve performance issues.
 
-- Check <<General procedure>>
+==== UnifiedPushJavaGCTimePerMinuteScavenge
 
-=== UnifiedPushPodMemoryHigh
+It means that Service pod(s) are facing performance issues.
 
-- Check <<General procedure>>
+. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
+. Following the steps <<To scale the pod>> in order to try to solve performance issues.
 
-=== UnifiedPushApiHighRequestDuration
+=== Warning
 
-- Check <<General procedure>>
+==== UnifiedPushMessagesFailures
 
-=== UnifiedPushApiHighConcurrentRequests
+It means that Service pod(s) has some error that is not able to send the quantity of messages expected.
 
-- Check <<General procedure>>
+. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
 
-=== UnifiedPushJavaDeadlockedThreads,
+==== UnifiedPushPodMemoryHigh
 
-- Check <<General procedure>>
+It means that Service pod(s) are facing performance issues.
 
-== General procedure
+. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
+. Following the steps <<To scale the pod>> in order to try to solve performance issues.
+
+==== UnifiedPushApiHighRequestDuration
+
+It means that the requests performed to the UPS Service are taking too long.
+
+. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
+. Following the steps <<To scale the pod>> in order to try to solve performance issues.
+
+==== UnifiedPushApiHighConcurrentRequests
+
+It means that are to many requests to the UPS Service falling.
+
+. Please following the <<To capture the logs>> procedure before in order to capture the logs and send it to its maintainers.
+
+TIP: May delete the UPS Deployment could allow the operator re-create it with the correct configuration.
+
+==== UnifiedPushJavaDeadlockedThreads,
+
+It means that are threads locked in the UPS Service.
+
+. Please following the <<To capture the logs>> procedure before in order to capture the logs and send it to its maintainers.
+
+TIP: May delete the UPS Deployment could allow the operator re-create it with the correct configuration.
+
+=== To capture the logs
 
 . Capture a snapshot of the 'UnifiedPush Server' Grafana dashboard and track it over time. The metrics can be useful for identifying performance issues over time.
 
 . Capture application logs for analysis.
-.. Get the pod names by running `oc get pods`
+.. Get the pod names by running `oc get pods`. Following an example of teh expected result.
++
+[source,shell]
+----
+$ oc get pods
+NAME                                           READY     STATUS    RESTARTS   AGE
+example-unifiedpushserver-1-dk8vm              2/2       Running   2          9d
+example-unifiedpushserver-postgresql-1-bw8mt   1/1       Running   1          9d
+unifiedpush-operator-58c8877fd8-g6dvr          1/1       Running   3          9d
+----
++
 .. Save the logs by running `oc logs <database-podname> > <filename>.log` for each pod
++
+NOTE: You can get the logs from the Console (OCP UI) as well.
++
+IMPORTANT: Capture this data will be useful in order to provide the required information for its maintainers are able to check it.
 
-NOTE: You are able to the the logs by the Console (OCP UI) as well.
+=== To scale the pod
 
-. If necessary, recreate the service pod to restore service.
-. Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc[UnifiedPushOperatorDown]
+Currently, is not possible scale the UPS Server and its Database
 
+== Validate
+
+=== Installation
+
+Following the steps to ensure that all is as expected.
+
+. Switch to the UPS namespace by running `oc project <namespace>`. E.g `oc project unifiedpush`
+. Check that the link:./deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml[UnifiedPushServer CR] or link:./deploy/crds/push_v1alpha1_unifiedpushserver_cr_with_backup[UnifiedPushServerWithBackup CR] is deployed in the same namespace as the operator by running `oc get UnifiedPushServer`. Following the expected result.
++
+NOTE: Just one kind of UnifiedPushServer CR can be applied, however, if the backup service is enable for your installation then it means that it is using the ink:./deploy/crds/push_v1alpha1_unifiedpushserver_cr_with_backup[UnifiedPushServerWithBackup CR].
++
+[source,shell]
+----
+$ oc get UnifiedPushServer
+NAME                        AGE
+example-unifiedpushserver   9d
+----
++
+IMPORTANT: This CR will install and configure the Database and Service pods.
++
+. Check if it has at least 3 pods running which each one will be with the Database, Server and Operator by running `oc get pods`. Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get pods
+NAME                                           READY     STATUS    RESTARTS   AGE
+example-unifiedpushserver-1-dk8vm              2/2       Running   4          12d
+example-unifiedpushserver-postgresql-1-bw8mt   1/1       Running   2          12d
+unifiedpush-operator-58c8877fd8-g6dvr          1/1       Running   6          12d
+----
++
+. Check if the secret with the Database data which will be used by the service and its database was created by running `oc get secrets | grep postgresql`.  Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get secrets | grep postgresql
+example-unifiedpushserver-postgresql        Opaque                                6         12d
+----
++
+. Check if the image streams for the Service and Oauth was created with success by running `oc get imagestream`.  Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get imagestream
+NAME                          DOCKER REPO                                               TAGS      UPDATED
+ups-imagestream               172.30.1.1:5000/unifiedpush/ups-imagestream               latest    12 days ago
+ups-oauth-proxy-imagestream   172.30.1.1:5000/unifiedpush/ups-oauth-proxy-imagestream   latest    12 days ago
+----
++
+. Check if the route to expose the service public was created with success by running `oc get route | grep unifiedpush-proxy`.  Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get route | grep unifiedpush-proxy
+example-unifiedpushserver-unifiedpush-proxy   example-unifiedpushserver-unifiedpush-proxy-unifiedpush.192.168.64.27.nip.io             example-unifiedpushserver-unifiedpush-proxy   <all>     edge/None     None
+----
+. Check if the DeploymentConfigs to deploy the Service and Database were created with success by running `oc get deploymentconfig | grep unifiedpush`.  Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get deploymentconfig | grep unifiedpush
+example-unifiedpushserver              1          1         1         config,image(postgresql:postgresql:10),image(ups-imagestream:latest),image(ups-oauth-proxy-imagestream:latest)
+example-unifiedpushserver-postgresql   1          1         1         image(postgresql:10)
+----
++
+. Check if the Proxy Service which is required to allow the UPS Server persist data into its Database was created with success by running `oc get service | grep unifiedpush-proxy`
++
+[source,shell]
+----
+$ oc get service | grep unifiedpush-proxy
+example-unifiedpushserver-unifiedpush-proxy   ClusterIP   172.30.189.9     <none>        80/TCP     12d
+----
++
+. Check if the  Service for the Database was created with success by running `oc get service | grep postgresql`
++
+[source,shell]
+----
+$ oc get service | grep postgresql
+example-unifiedpushserver-postgresql          ClusterIP   172.30.67.199    <none>        5432/TCP   12d
+----
++
+. Check if the Service for the Service was created with success by running `oc get service | grep unifiedpushserver`
++
+[source,shell]
+----
+$ oc get service | grep unifiedpushserver
+example-unifiedpushserver-postgresql          ClusterIP   172.30.67.199    <none>        5432/TCP   12d
+example-unifiedpushserver-unifiedpush         ClusterIP   172.30.90.23     <none>        80/TCP     12d
+example-unifiedpushserver-unifiedpush-proxy   ClusterIP   172.30.189.9     <none>        80/TCP     12d
+----
++
+Following an example of an installation which has the UPS installed without the Backup.
++
+[source,shell]
+----
+$ oc get all
+NAME                                               READY     STATUS    RESTARTS   AGE
+pod/example-unifiedpushserver-1-dk8vm              2/2       Running   4          12d
+pod/example-unifiedpushserver-postgresql-1-bw8mt   1/1       Running   2          12d
+pod/unifiedpush-operator-58c8877fd8-g6dvr          1/1       Running   6          12d
+
+NAME                                                           DESIRED   CURRENT   READY     AGE
+replicationcontroller/example-unifiedpushserver-1              1         1         1         12d
+replicationcontroller/example-unifiedpushserver-postgresql-1   1         1         1         12d
+
+NAME                                                  TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+service/example-unifiedpushserver-postgresql          ClusterIP   172.30.67.199    <none>        5432/TCP   12d
+service/example-unifiedpushserver-unifiedpush         ClusterIP   172.30.90.23     <none>        80/TCP     12d
+service/example-unifiedpushserver-unifiedpush-proxy   ClusterIP   172.30.189.9     <none>        80/TCP     12d
+service/unifiedpush-operator                          ClusterIP   172.30.132.236   <none>        8383/TCP   12d
+
+NAME                                   DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/unifiedpush-operator   1         1         1            1           12d
+
+NAME                                              DESIRED   CURRENT   READY     AGE
+replicaset.apps/unifiedpush-operator-58c8877fd8   1         1         1         12d
+
+NAME                                                                      REVISION   DESIRED   CURRENT   TRIGGERED BY
+deploymentconfig.apps.openshift.io/example-unifiedpushserver              1          1         1         config,image(postgresql:postgresql:10),image(ups-imagestream:latest),image(ups-oauth-proxy-imagestream:latest)
+deploymentconfig.apps.openshift.io/example-unifiedpushserver-postgresql   1          1         1         image(postgresql:10)
+
+NAME                                                         DOCKER REPO                                               TAGS      UPDATED
+imagestream.image.openshift.io/ups-imagestream               172.30.1.1:5000/unifiedpush/ups-imagestream               latest    12 days ago
+imagestream.image.openshift.io/ups-oauth-proxy-imagestream   172.30.1.1:5000/unifiedpush/ups-oauth-proxy-imagestream   latest    12 days ago
+
+NAME                                                                   HOST/PORT                                                                      PATH      SERVICES                                      PORT      TERMINATION   WILDCARD
+route.route.openshift.io/example-unifiedpushserver-unifiedpush-proxy   example-unifiedpushserver-unifiedpush-proxy-unifiedpush.192.168.64.27.nip.io             example-unifiedpushserver-unifiedpush-proxy   <all>     edge/None     None
+----
+
+=== Optional configurations
+
+==== Monitor
+
+If the https://github.com/aerogear/unifiedpush-operator#monitoring-service-metrics[Monitoring Service (Metrics)] is enabled for your installation you are able to check its Grafana Dashboard, `UnifiedPush Server`, and the Prometheus Monitoring instance used for it.
+
+==== Backup
+
+. Switch to the UPS namespace by running `oc project <namespace>`. E.g `oc project unifiedpush`
+. Check that link:./deploy/crds/push_v1alpha1_unifiedpushserver_cr_with_backup[UnifiedPushServerWithBackup CR] is deployed in the same namespace as the operator by running `oc get UnifiedPushServer`. Following the expected result.
++
+NOTE: Just one kind of UnifiedPushServer CR can be applied, however, if the backup service is enable for your installation then it means that it is using the ink:./deploy/crds/push_v1alpha1_unifiedpushserver_cr_with_backup[UnifiedPushServerWithBackup CR].
++
+[source,shell]
+----
+$ oc get UnifiedPushServer
+NAME                        AGE
+example-unifiedpushserver   9d
+----
++
+. To ensure that it is the UnifiedPushServer with the Backup see its specs by running `oc describe UnifiedPushServer`.
+.. Following an example without Backup installed.
++
+[source,shell]
+----
+$ oc describe UnifiedPushServer
+Name:         example-unifiedpushserver
+Namespace:    unifiedpush
+Labels:       <none>
+Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"push.aerogear.org/v1alpha1","kind":"UnifiedPushServer","metadata":{"annotations":{},"name":"example-unifiedpushserver","namespace":"unif...
+API Version:  push.aerogear.org/v1alpha1
+Kind:         UnifiedPushServer
+Metadata:
+  Creation Timestamp:  2019-07-04T00:44:47Z
+  Generation:          1
+  Resource Version:    7026921
+  Self Link:           /apis/push.aerogear.org/v1alpha1/namespaces/unifiedpush/unifiedpushservers/example-unifiedpushserver
+  UID:                 ec430bf1-9df4-11e9-817f-beb071062273
+Status:
+  Phase:  Complete
+Events:   <none>
+----
+.. Following an example with the Backup
++
+[source,shell]
+----
+$ oc describe UnifiedPushServer
+Name:         example-unifiedpushserver
+Namespace:    unifiedpush
+Labels:       <none>
+Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"push.aerogear.org/v1alpha1","kind":"UnifiedPushServer","metadata":{"annotations":{},"name":"example-unifiedpushserver","namespace":"unif...
+API Version:  push.aerogear.org/v1alpha1
+Kind:         UnifiedPushServer
+Metadata:
+  Creation Timestamp:  2019-07-04T00:44:47Z
+  Generation:          1
+  Resource Version:    7026921
+  Self Link:           /apis/push.aerogear.org/v1alpha1/namespaces/unifiedpush/unifiedpushservers/example-unifiedpushserver
+  UID:                 ec430bf1-9df4-11e9-817f-beb071062273
+Status:
+  Phase:  Complete
+Events:   <none>
+
+
+Name:         example-ups-with-backups
+Namespace:    unifiedpush
+Labels:       <none>
+Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"push.aerogear.org/v1alpha1","kind":"UnifiedPushServer","metadata":{"annotations":{},"name":"example-ups-with-backups","namespace":"unifi...
+API Version:  push.aerogear.org/v1alpha1
+Kind:         UnifiedPushServer
+Metadata:
+  Creation Timestamp:  2019-07-16T08:51:47Z
+  Generation:          1
+  Resource Version:    8621940
+  Self Link:           /apis/push.aerogear.org/v1alpha1/namespaces/unifiedpush/unifiedpushservers/example-ups-with-backups
+  UID:                 f20c5f0b-a7a6-11e9-a6b1-beb071062273
+Spec:
+  Backups:
+    Backend Secret Name:              example-aws-key
+    Backend Secret Namespace:         unifiedpush
+    Encryption Key Secret Name:       example-encryption-key
+    Encryption Key Secret Namespace:  unifiedpush
+    Name:                             ups-daily-at-midnight
+    Schedule:                         0 0 * * *
+Events:                               <none>
+----
++
+. To verify that the backup has been successfully created you can run the following command in the namespace where the operator is installed.
++
+[source,shell]
+----
+$ oc get cronjob.batch/example-ups-with-backups
+NAME                             SCHEDULE      SUSPEND   ACTIVE    LAST SCHEDULE   AGE
+example-ups-with-backups   0 * * * *   False     0         13s             12m
+----
++
+. To check the jobs executed you can run the command `oc get jobs` in the namespace where the operator is installed as in the following example.
++
+[source,shell]
+----
+$ oc get jobs
+NAME                                 DESIRED   SUCCESSFUL   AGE
+example-ups-with-backups-1561588320   1         0            6m
+example-ups-with-backups-1561588380   1         0            5m
+example-ups-with-backups-1561588440   1         0            4m
+example-ups-with-backups-1561588500   1         0            3m
+example-ups-with-backups-1561588560   1         0            2m
+example-ups-with-backups-1561588620   1         0            1m
+example-ups-with-backups-1561588680   1         0            43s
+----
++
+NOTE: In the above example the schedule was made to run this job each minute (`*/1 * * * *`)
++
+. To check the logs and troubleshooting you can run the command `oc logs $podName -f` in the namespace where the operator is installed as the following example.
++
+[source,shell]
+----
+$ oc logs job.batch/example-ups-with-backups-1561589040 -f
+dumping ups
+dumping postgres
+==> Component data dump completed
+/tmp/intly/archives/ups.ups-22_46_06.pg_dump.gz
+WARNING: ups.ups-22_46_06.pg_dump.gz: Owner username not known. Storing UID=1001 instead.
+upload: '/tmp/intly/archives/ups.ups-22_46_06.pg_dump.gz' -> 's3://camilabkp/backups/mss/postgres/2019/06/26/ups.ups-22_46_06.pg_dump.gz'  [1 of 1]
+1213 of 1213   100% in    1s   955.54 B/s  done
+ERROR: S3 error: 403 (RequestTimeTooSkewed): The difference between the request time and the current time is too large.
+----

--- a/deploy/monitor/prometheus_rule.yaml
+++ b/deploy/monitor/prometheus_rule.yaml
@@ -23,7 +23,7 @@ spec:
           description: "The UnifiedPush Operator has been down for more than 5 minutes. "
           summary: "The UnifiedPush Operator is down. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
           sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc"
-      - alert: UnifiedPushPodcount
+      - alert: UnifiedPushPodCount
         annotations:
           description: "The Pod count for the UnifiedPush Server has changed in the last 5 minutes and is lower than the required minimum."
           summary: "Pod count for namespace UnifiedPush is {{ printf '%.0f' $value }}. Expected 3 pods at least. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"

--- a/deploy/monitor/push_grafana_dashboard.yaml
+++ b/deploy/monitor/push_grafana_dashboard.yaml
@@ -49,1333 +49,1164 @@ spec:
           ],
           "annotations": {
             "list": [
-              {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-              }
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "type": "dashboard"
+            }
             ]
           },
           "description": "Application metrics",
           "editable": true,
           "gnetId": null,
           "graphTooltip": 0,
-          "id": null,
           "links": [],
           "panels": [
+          {
+            "collapsed": false,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "id": 9,
+            "panels": [],
+            "repeat": null,
+            "title": "Uptime",
+            "type": "row"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#d44a3a",
+              "rgba(237, 129, 40, 0.89)",
+              "#299c46"
+            ],
+            "datasource": "Prometheus",
+            "decimals": null,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 95,
+              "show": true,
+              "thresholdLabels": true,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 3,
+              "x": 0,
+              "y": 1
+            },
+            "id": 8,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
             {
-              "collapsed": false,
-              "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 0
-              },
-              "id": 9,
-              "panels": [],
-              "repeat": null,
-              "title": "Uptime",
-              "type": "row"
+              "name": "value to text",
+              "value": 1
             },
             {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "#d44a3a",
-                "rgba(237, 129, 40, 0.89)",
-                "#299c46"
-              ],
-              "datasource": "Prometheus",
-              "decimals": null,
-              "format": "percent",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 95,
-                "show": true,
-                "thresholdLabels": true,
-                "thresholdMarkers": true
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 3,
-                "x": 0,
-                "y": 1
-              },
-              "id": 8,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-              },
-              "tableColumn": "",
-              "targets": [
-                {
-                  "expr": "avg(kube_endpoint_address_available{endpoint='example-unifiedpushserver-unifiedpush'})*100",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "refId": "A"
-                }
-              ],
-              "thresholds": "98,99",
-              "title": "Admin Console Average Percentage Uptime",
-              "transparent": false,
-              "type": "singlestat",
-              "valueFontSize": "70%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "avg"
-            },
-            {
-              "aliasColors": {},
-              "bars": true,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "Prometheus",
-              "fill": 1,
-              "gridPos": {
-                "h": 8,
-                "w": 21,
-                "x": 3,
-                "y": 1
-              },
-              "id": 1,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [
-                {
-                  "type": "dashboard"
-                }
-              ],
-              "nullPointMode": "null",
-              "percentage": true,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "kube_endpoint_address_available{endpoint='example-unifiedpushserver-unifiedpush'}",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 2,
-                  "legendFormat": "Admin Console - Uptime",
-                  "metric": "",
-                  "refId": "A",
-                  "step": 2
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "Admin Console - Uptime",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "none",
-                  "label": null,
-                  "logBase": null,
-                  "max": 1.5,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": null,
-                  "max": 2,
-                  "min": 0,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "#d44a3a",
-                "rgba(237, 129, 40, 0.89)",
-                "#299c46"
-              ],
-              "datasource": "Prometheus",
-              "format": "percent",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 95,
-                "show": true,
-                "thresholdLabels": true,
-                "thresholdMarkers": true
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 3,
-                "x": 0,
-                "y": 9
-              },
-              "id": 16,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-              },
-              "tableColumn": "",
-              "targets": [
-                {
-                  "expr": "avg(kube_pod_container_status_running{namespace='unifiedpush',container='postgresql'})*100",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "refId": "A"
-                }
-              ],
-              "thresholds": "98,99",
-              "title": "Database Average Percentage - Uptime",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "avg"
-            },
-            {
-              "aliasColors": {},
-              "bars": true,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "Prometheus",
-              "fill": 1,
-              "gridPos": {
-                "h": 8,
-                "w": 21,
-                "x": 3,
-                "y": 9
-              },
-              "id": 12,
-              "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": true,
-              "targets": [
-                {
-                  "expr": "kube_pod_container_status_running{namespace='unifiedpush',container='postgresql'}",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "legendFormat": "Postgres postgresql - Uptime",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "UnifiedPush Database - Uptime",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "#d44a3a",
-                "rgba(237, 129, 40, 0.89)",
-                "#299c46"
-              ],
-              "datasource": "Prometheus",
-              "format": "percent",
-              "gauge": {
-                "maxValue": 100,
-                "minValue": 95,
-                "show": true,
-                "thresholdLabels": true,
-                "thresholdMarkers": true
-              },
-              "gridPos": {
-                "h": 8,
-                "w": 3,
-                "x": 0,
-                "y": 17
-              },
-              "id": 18,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-              },
-              "tableColumn": "",
-              "targets": [
-                {
-                  "expr": "avg(kube_pod_container_status_running{namespace='unifiedpush',container='ups'})*100",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "refId": "A"
-                }
-              ],
-              "thresholds": "98,99",
-              "title": "UnifiedPush Server Average Percentage Uptime",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "avg"
-            },
-            {
-              "aliasColors": {},
-              "bars": true,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "Prometheus",
-              "fill": 1,
-              "gridPos": {
-                "h": 8,
-                "w": 21,
-                "x": 3,
-                "y": 17
-              },
-              "id": 14,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": true,
-              "targets": [
-                {
-                  "expr": "kube_pod_container_status_running{namespace='unifiedpush',container='ups'}",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "UnifiedPush Server - Uptime",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "UnifiedPush Server  - Uptime",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "collapsed": false,
-              "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 25
-              },
-              "id": 10,
-              "panels": [],
-              "repeat": null,
-              "title": "Messages",
-              "type": "row"
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "Prometheus",
-              "fill": 1,
-              "gridPos": {
-                "h": 8,
-                "w": 24,
-                "x": 0,
-                "y": 26
-              },
-              "id": 4,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(rate(ups_msg_fails_total{namespace='unifiedpush'}[1m]))*1000",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "Failures",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "Failures",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "bytes",
-                  "label": null,
-                  "logBase": 2,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "Prometheus",
-              "fill": 1,
-              "gridPos": {
-                "h": 8,
-                "w": 24,
-                "x": 0,
-                "y": 34
-              },
-              "id": 2,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum(rate(ups_msg_total{namespace='unifiedpush'}[1m]))*1000",
-                  "format": "time_series",
-                  "interval": "",
-                  "intervalFactor": 2,
-                  "legendFormat": "Messages",
-                  "refId": "A",
-                  "step": 2
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "Messages",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "transparent": false,
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "label": "Millicores",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "collapsed": false,
-              "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 42
-              },
-              "id": 20,
-              "panels": [],
-              "title": "API HTTP Monitoring",
-              "type": "row"
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "Prometheus",
-              "fill": 1,
-              "gridPos": {
-                "h": 9,
-                "w": 24,
-                "x": 0,
-                "y": 43
-              },
-              "id": 28,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "(api_requests_duration_seconds{job='example-unifiedpushserver-unifiedpush'})",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "legendFormat": "{{method}} {{path}}",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "API Requests Duration",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "s",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": "0",
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "Prometheus",
-              "fill": 1,
-              "gridPos": {
-                "h": 8,
-                "w": 8,
-                "x": 0,
-                "y": 52
-              },
-              "id": 30,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "rate(api_requests_failure_total[30m])",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "legendFormat": "Errors {{code}} - {{method}} {{path}}",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "Rate of HTTP Errors Per Second",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "decimals": null,
-                  "format": "short",
-                  "label": "Rate of HTTP Errors/Second",
-                  "logBase": 1,
-                  "max": null,
-                  "min": "0",
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "Prometheus",
-              "fill": 1,
-              "gridPos": {
-                "h": 8,
-                "w": 10,
-                "x": 8,
-                "y": 52
-              },
-              "id": 32,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [],
-              "nullPointMode": "null",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "rate(api_requests_total[1h])",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "legendFormat": "{{method}} - {{code}} - {{path}}",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "Rate of  HTTP Responses",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "label": "Rate of HTTP Responses/Second",
-                  "logBase": 1,
-                  "max": null,
-                  "min": "0",
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-              ],
-              "datasource": "Prometheus",
-              "format": "s",
-              "gauge": {
-                "maxValue": 40,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": true,
-                "thresholdMarkers": true
-              },
-              "gridPos": {
-                "h": 4,
-                "w": 3,
-                "x": 18,
-                "y": 52
-              },
-              "id": 26,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-              },
-              "tableColumn": "",
-              "targets": [
-                {
-                  "expr": "max(api_requests_duration_seconds{job='example-unifiedpushserver-unifiedpush'})",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "refId": "A"
-                }
-              ],
-              "thresholds": "25,30",
-              "title": "Max API Requests Duration",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "max"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-              ],
-              "datasource": "Prometheus",
-              "format": "s",
-              "gauge": {
-                "maxValue": 40,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": true,
-                "thresholdMarkers": true
-              },
-              "gridPos": {
-                "h": 4,
-                "w": 3,
-                "x": 21,
-                "y": 52
-              },
-              "id": 34,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-              },
-              "tableColumn": "",
-              "targets": [
-                {
-                  "expr": "min(api_requests_duration_seconds{job='example-unifiedpushserver-unifiedpush'})",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "refId": "A"
-                }
-              ],
-              "thresholds": "25,30",
-              "title": "Minium API Requests Duration Seconds",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "min"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-              ],
-              "datasource": "Prometheus",
-              "format": "s",
-              "gauge": {
-                "maxValue": 40,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": true,
-                "thresholdMarkers": true
-              },
-              "gridPos": {
-                "h": 4,
-                "w": 3,
-                "x": 18,
-                "y": 56
-              },
-              "id": 24,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-              },
-              "tableColumn": "",
-              "targets": [
-                {
-                  "expr": "avg(api_requests_duration_seconds{job='example-unifiedpushserver-unifiedpush'})",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "refId": "A"
-                }
-              ],
-              "thresholds": "25, 30",
-              "title": "Average API Requests Duration",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "avg"
-            },
-            {
-              "cacheTimeout": null,
-              "colorBackground": false,
-              "colorValue": false,
-              "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-              ],
-              "datasource": "Prometheus",
-              "format": "none",
-              "gauge": {
-                "maxValue": 40,
-                "minValue": 0,
-                "show": true,
-                "thresholdLabels": true,
-                "thresholdMarkers": true
-              },
-              "gridPos": {
-                "h": 4,
-                "w": 3,
-                "x": 21,
-                "y": 56
-              },
-              "id": 22,
-              "interval": null,
-              "links": [],
-              "mappingType": 1,
-              "mappingTypes": [
-                {
-                  "name": "value to text",
-                  "value": 1
-                },
-                {
-                  "name": "range to text",
-                  "value": 2
-                }
-              ],
-              "maxDataPoints": 100,
-              "nullPointMode": "connected",
-              "nullText": null,
-              "postfix": "",
-              "postfixFontSize": "50%",
-              "prefix": "",
-              "prefixFontSize": "50%",
-              "rangeMaps": [
-                {
-                  "from": "null",
-                  "text": "N/A",
-                  "to": "null"
-                }
-              ],
-              "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-              },
-              "tableColumn": "",
-              "targets": [
-                {
-                  "expr": "avg(api_requests_in_flight{job='example-unifiedpushserver-unifiedpush'})",
-                  "format": "time_series",
-                  "hide": false,
-                  "intervalFactor": 1,
-                  "legendFormat": "",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": "15 ,20",
-              "title": "Average API requests in flight",
-              "type": "singlestat",
-              "valueFontSize": "80%",
-              "valueMaps": [
-                {
-                  "op": "=",
-                  "text": "N/A",
-                  "value": "null"
-                }
-              ],
-              "valueName": "avg"
+              "name": "range to text",
+              "value": 2
             }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+            ],
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+            {
+              "expr": "avg(kube_endpoint_address_available{endpoint='example-unifiedpushserver-unifiedpush'})*100",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+            ],
+            "thresholds": "98,99",
+            "title": "Admin Console Average Percentage Uptime",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "70%",
+            "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "aliasColors": {},
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "decimals": 0,
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 21,
+              "x": 3,
+              "y": 1
+            },
+            "id": 1,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [
+            {
+              "type": "dashboard"
+            }
+            ],
+            "nullPointMode": "null",
+            "percentage": true,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+            {
+              "expr": "kube_endpoint_address_available{endpoint='example-unifiedpushserver-unifiedpush'}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "uptime service endpoint",
+              "metric": "",
+              "refId": "A",
+              "step": 2
+            }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Admin Console - Uptime",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": null,
+              "max": 1.5,
+              "min": 0,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": null,
+              "max": 2,
+              "min": 0,
+              "show": true
+            }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#d44a3a",
+              "rgba(237, 129, 40, 0.89)",
+              "#299c46"
+            ],
+            "datasource": "Prometheus",
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 95,
+              "show": true,
+              "thresholdLabels": true,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 3,
+              "x": 0,
+              "y": 9
+            },
+            "id": 16,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+            ],
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+            {
+              "expr": "avg(kube_pod_container_status_running{namespace='unifiedpush',container='postgresql'})*100",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+            ],
+            "thresholds": "98,99",
+            "title": "Database Average Percentage - Uptime",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "aliasColors": {},
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 21,
+              "x": 3,
+              "y": 9
+            },
+            "id": 12,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+            {
+              "expr": "avg(kube_pod_container_status_running{namespace='unifiedpush',container='postgresql'})",
+              "format": "time_series",
+              "hide": false,
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "database container ",
+              "refId": "A"
+            }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "UnifiedPush Database - Uptime",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#d44a3a",
+              "rgba(237, 129, 40, 0.89)",
+              "#299c46"
+            ],
+            "datasource": "Prometheus",
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 95,
+              "show": true,
+              "thresholdLabels": true,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 3,
+              "x": 0,
+              "y": 17
+            },
+            "id": 18,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+            ],
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+            {
+              "expr": "avg(kube_pod_container_status_running{namespace='unifiedpush',container='ups'})*100",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+            ],
+            "thresholds": "98,99",
+            "title": "UnifiedPush Server Average Percentage Uptime",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "aliasColors": {},
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 21,
+              "x": 3,
+              "y": 17
+            },
+            "id": 14,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": false,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+            {
+              "expr": "avg(kube_pod_container_status_running{namespace='unifiedpush',container='ups'})",
+              "format": "time_series",
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "server container",
+              "refId": "A"
+            }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "UnifiedPush Server  - Uptime",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 25
+            },
+            "id": 10,
+            "panels": [],
+            "repeat": null,
+            "title": "Resources",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 26
+            },
+            "id": 40,
+            "interval": "1s",
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+            {
+              "expr": "max(jvm_memory_bytes_used{area='heap',namespace='unifiedpush'}) + max(jvm_memory_bytes_used{area='nonheap', namespace='unifiedpush'})",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "JVM memory",
+              "refId": "A"
+            }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Current Memory",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 32,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 32,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 34
+            },
+            "id": 41,
+            "interval": "1s",
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+            {
+              "expr": "sum(jvm_memory_bytes_max{namespace=\"unifiedpush\"})",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "max",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(jvm_memory_bytes_committed{namespace=\"unifiedpush\"})",
+              "format": "time_series",
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "commited",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(jvm_memory_bytes_used{namespace=\"unifiedpush\"})",
+              "format": "time_series",
+              "hide": false,
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "used",
+              "refId": "C"
+            }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 32,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 32,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 42
+            },
+            "id": 42,
+            "interval": "1s",
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+            {
+              "expr": "sum(process_cpu_seconds_total{namespace=\"unifiedpush\"})",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "used",
+              "refId": "A"
+            }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+            {
+              "format": "mbytes",
+              "label": null,
+              "logBase": 32,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 32,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 50
+            },
+            "id": 20,
+            "panels": [],
+            "title": "API Monitoring",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "decimals": 0,
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 51
+            },
+            "id": 35,
+            "interval": "1m",
+            "legend": {
+              "alignAsTable": false,
+              "avg": true,
+              "current": false,
+              "hideEmpty": false,
+              "max": false,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+            {
+              "expr": "sum(aerogear_ups_push_requests_total{namespace='unifiedpush',service='example-unifiedpushserver-unifiedpush'})",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "attempts",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(aerogear_ups_push_requests_fail_total{namespace='unifiedpush',service='example-unifiedpushserver-unifiedpush'})",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "1s",
+              "intervalFactor": 1,
+              "legendFormat": "failures",
+              "refId": "B"
+            }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Push Notifications",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": null,
+              "logBase": 10,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "decimals": 0,
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 51
+            },
+            "id": 39,
+            "interval": "1m",
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+            {
+              "expr": "sum(aerogear_ups_push_requests_ios{namespace='unifiedpush',service='example-unifiedpushserver-unifiedpush'})",
+              "format": "time_series",
+              "hide": false,
+              "interval": "1m",
+              "intervalFactor": 1,
+              "legendFormat": "ios",
+              "refId": "C"
+            },
+            {
+              "expr": "sum(aerogear_ups_push_requests_android{namespace='unifiedpush',service='example-unifiedpushserver-unifiedpush'})",
+              "format": "time_series",
+              "hide": false,
+              "interval": "1m",
+              "intervalFactor": 1,
+              "legendFormat": "android",
+              "refId": "D"
+            }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Push Notifications per Platform",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": null,
+              "logBase": 10,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 59
+            },
+            "id": 36,
+            "interval": "1m",
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+            {
+              "expr": "aerogear_ups_device_register_requests_total{namespace='unifiedpush',service='example-unifiedpushserver-unifiedpush'}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "requests to register devices",
+              "refId": "A"
+            }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Devices",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 2,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
           ],
-          "refresh": "10s",
+          "refresh": false,
           "schemaVersion": 16,
           "style": "dark",
           "tags": [],
@@ -1414,6 +1245,6 @@ spec:
           "timezone": "browser",
           "title": "UnifiedPush Server",
           "uid": "_cxgpLnZx",
-          "version": 2
+          "version": 1
         }
   name: unifiedpushserver.json

--- a/deploy/monitor/push_prometheus_rule.yaml
+++ b/deploy/monitor/push_prometheus_rule.yaml
@@ -14,7 +14,7 @@ spec:
   groups:
     - name: general.rules
       rules:
-      - alert: UnifiedpushDown
+      - alert: UnifiedPushDown
         expr: absent(kube_pod_container_status_running{namespace="unifiedpush",container="ups"}==1)
         for: 5m
         labels:

--- a/deploy/monitor/push_prometheus_rule.yaml
+++ b/deploy/monitor/push_prometheus_rule.yaml
@@ -15,77 +15,32 @@ spec:
     - name: general.rules
       rules:
       - alert: UnifiedPushDown
-        expr: absent(kube_pod_container_status_running{namespace="unifiedpush",container="ups"}==1)
+        expr: absent(kube_pod_container_status_running{namespace="unifiedpush",container="ups"} >= 1)
         for: 5m
         labels:
           severity: critical
         annotations:
           description: "The UnifiedPush Pod Server has been down for more than 5 minutes. "
           summary: "The UnifiedPush Pod Server is down. For more information see on the UnifiedPush at https://github.com/aerogear/aerogear-unifiedpush-server"
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
       - alert: UnifiedPushConsoleDown
-        expr: absent(kube_endpoint_address_available{endpoint="example-unifiedpushserver-unifiedpush"} == 1)
+        expr: absent(kube_endpoint_address_available{endpoint="example-unifiedpushserver-unifiedpush"} >= 1)
         for: 5m
         labels:
           severity: critical
         annotations:
           description: "The UnifiedPush admin console has been down for more than 5 minutes. "
           summary: "The UnifiedPush admin console endpoint has been unavailable for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
       - alert: UnifiedPushDatabaseDown
-        expr: absent(kube_pod_container_status_running{namespace="unifiedpush",container="postgresql"}==1)
+        expr: absent(kube_pod_container_status_running{namespace="unifiedpush",container="postgresql"} >= 1)
         for: 5m
         labels: 
           severity: critical
         annotations:
           description: "The UnifiedPush Database pod has been down for more than 5 minutes"
           summary: "The UnifiedPush Database is down. For more information see on the UnifiedPush at https://github.com/aerogear/aerogear-unifiedpush-serve"
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
-      - alert: UnifiedPushPodCPUHigh # todo check if it will work after expse the metrcis
-        expr: "(rate(process_cpu_seconds_total{job='example-unifiedpushserver-unifiedpush'}[1m])) > (((kube_pod_container_resource_limits_cpu_cores{namespace='mobile-security-service',container='application'})/100)*90)"
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          description: "The UnifiedPush Server Pod has been at 90% CPU usage for more than 5 minutes"
-          summary: "The UnifiedPush Server Pod is reporting high cpu usage for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
-      - alert: UnifiedPushPodMemoryHigh # todo check if it will work after expse the metrcis
-        expr: "(process_resident_memory_bytes{job='example-unifiedpushserver-unifiedpush'}) > (((kube_pod_container_resource_limits_memory_bytes{namespace='unifiedpush',container='ups'})/100)*90)"
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          description: "The UnifiedPush API has been at 90% memory usage for more than 5 minutes"
-          summary: "The UnifiedPush API is reporting high memory usage for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
-      - alert: UnifiedPushApiHighRequestDuration # todo expose metric
-        expr: "api_requests_duration_seconds{job='example-unifiedpushserver-unifiedpush', quantile='0.5'} > 30"
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          description: "The UnifiedPush API has had http requests latency longer that 30 seconds for more than 5 minutes"
-          summary: "The UnifiedPush API is reporting high request latency for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
-      - alert: UnifiedPushApiHighConcurrentRequests # todo expose metric
-        expr: "api_requests_in_flight{job='example-unifiedpushserver-unifiedpush'} > 50"
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          description: "The UnifiedPush API has had 50 concurrent requests for more than 5 minutes"
-          summary: "The UnifiedPush API is reporting high request concurrency for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
-      - alert: UnifiedPushApHighRequestFailure # todo expose metric
-        expr: "rate(api_requests_failure_total{job='example-unifiedpushserver-unifiedpush'}[1h])>10"
-        for: 1h
-        labels:
-          severity: critical
-        annotations:
-          description: "The UnifiedPush API has reported more that 10 request failures in an hour"
-          summary: "The UnifiedPush API is reporting a high request failure over an hour. For more information see on the UnifiedPush ServerServer at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
       - alert:  UnifiedPushJavaHeapThresholdExceeded
         expr: |
           100 * jvm_memory_bytes_used{area="heap",namespace="unifiedpush"}
@@ -97,7 +52,7 @@ spec:
         annotations:
           description: "The Heap Usage of the UnifiedPush Server exceeded 90% of usage"
           summary: "The UnifiedPush Server JVM Heap Threshold Exceeded 90% of usage. For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
       - alert: UnifiedPushJavaNonHeapThresholdExceeded
         expr: |
           100 * jvm_memory_bytes_used{area="nonheap",namespace="unifiedpush"}
@@ -109,17 +64,17 @@ spec:
         annotations:
           description: "The nonheap usage of the UnifiedPush Server exceeded 90% of usage"
           summary: "The nonheap usage of the UnifiedPush Server exceeded 90% of usage .For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
       - alert: UnifiedPushJavaGCTimePerMinuteScavenge
         expr: |
-          increase(jvm_gc_collection_seconds_sum{gc="PS Scavenge",namespace="unifiedpush"}[1m]) > 1 * 60 * 0.9
+          increase(jvm_gc_collection_seconds_sum{namespace="unifiedpush"}[1m]) > 1 * 60 * 0.9
         for: 1m
         labels:
           severity: critical
         annotations:
           description: "Amount of time per minute spent on garbage collection in the UnifiedPush Server pod exceeds 90%"
           summary: "Amount of time per minute spent on garbage collection in the UnifiedPush Server pod exceeds 90%. This could indicate that the available heap memory is insufficient..For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
       - alert: UnifiedPushJavaDeadlockedThreads
         expr: |
           jvm_threads_deadlocked{namespace="unifiedpush"}
@@ -130,15 +85,15 @@ spec:
         annotations:
           description: "Number of threads in deadlock state of the UnifiedPush Server > 0"
           summary: "Number of threads in deadlock state of the UnifiedPush Server > 0.For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
-      - alert: UnifiedPushMessagesFailures # todo expose metric
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
+      - alert: UnifiedPushMessagesFailures
         expr: >
-          rate(ups_msg_fails_total{namespace="unifiedpush"}[5m])
+          rate(aerogear_ups_push_requests_fail_total{namespace="unifiedpush"}[5m])
           * 300 > 50
         for: 5m
         labels:
           severity: warning
         annotations:
-          description: "More than 50 failed messages attempts for UnifiedPush Server fails over the last 5 minutes."
+          description: "More than 50 failed requests attempts for UnifiedPush Server fails over the last 5 minutes."
           summary: "More than 50 failed messages attempts for UnifiedPush Server fails over the last 5 minutes. For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc" #todo
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"

--- a/deploy/monitor/push_service_monitor.yaml
+++ b/deploy/monitor/push_service_monitor.yaml
@@ -7,8 +7,8 @@ metadata:
   name: unifiedpush
 spec:
   endpoints:
-    - path: /api/metrics
-      port: server
+    - path: /rest/prometheus/metrics
+      port: web
   selector:
     matchLabels:
-      app: unifiedpush
+      internal: unifiedpush


### PR DESCRIPTION
## Motivation
- https://issues.jboss.org/browse/INTLY-1443
- https://issues.jboss.org/browse/INTLY-2668

## What
- Address a few comments/suggestions made after the PR #43 get merged. 
- Add further details as expected results and NOTES in order to address the request/suggestions made by SRE.  
- Adjust/Fix Prometheus Rules + Dashboard with the real data exported by Push Server which is available now. 

## Verification Steps
### Regards: INTLY-1443
- See [here](https://github.com/aerogear/unifiedpush-operator/blob/ad4acef7a3e93cecf6b0ee18577e7596adfd112b/SOP/SOP-push.adoc) the SOP for push server. 
- See [here](https://github.com/aerogear/unifiedpush-operator/blob/ad4acef7a3e93cecf6b0ee18577e7596adfd112b/SOP/SOP-operator.adoc) the SOP for the operator. 

### Regards: INTLY-2668 
- See here the Grafana Dashboard: https://grafana-route-middleware-monitoring.apps.london-2f09.openshiftworkshop.com/d/_cxgpLnZx/unifiedpush-server?orgId=1
- See here the Prometheus rules: https://prometheus-route-middleware-monitoring.apps.london-2f09.openshiftworkshop.com/alerts

#### NOTES:
- It is using the image `passos/unifiedpush-configurable-container:prometheus`
- The image to check UPS Oper in the RHDS is: `cmacedo/unifiedpush-operator:INTLY-2668` (all is hardcoded so to change the image:tag is required to do a new image build)
- If you would like to test it in another env you need to use the dev/test image above in the operator.yaml and edit it before running the commands to install the project. 

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress
- [x] Finished task
- [] TODO 

## Extra
<img width="530" alt="Screenshot 2019-07-17 at 18 11 21" src="https://user-images.githubusercontent.com/7708031/61412102-52ec9600-a8be-11e9-968d-1857d1116d07.png">
