### PR TITLE
Only watch relevant namespaces for CRs

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,6 +22,10 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
+              value: ""
+            - name: APP_NAMESPACES
+              value: unifiedpush-apps
+            - name: SERVICE_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace

--- a/pkg/controller/androidvariant/androidvariant_controller.go
+++ b/pkg/controller/androidvariant/androidvariant_controller.go
@@ -6,6 +6,7 @@ import (
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	"github.com/aerogear/unifiedpush-operator/pkg/controller/util"
+	"github.com/aerogear/unifiedpush-operator/pkg/nspredicate"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +41,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource AndroidVariant
-	err = c.Watch(&source.Kind{Type: &pushv1alpha1.AndroidVariant{}}, &handler.EnqueueRequestForObject{})
+	onlyEnqueueForValidNamespaces, err := nspredicate.NewFromEnvVar("APP_NAMESPACES")
+	if err != nil {
+		return err
+	}
+	err = c.Watch(
+		&source.Kind{Type: &pushv1alpha1.AndroidVariant{}},
+		&handler.EnqueueRequestForObject{},
+		onlyEnqueueForValidNamespaces,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/iosvariant/iosvariant_controller.go
+++ b/pkg/controller/iosvariant/iosvariant_controller.go
@@ -6,6 +6,7 @@ import (
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	"github.com/aerogear/unifiedpush-operator/pkg/controller/util"
+	"github.com/aerogear/unifiedpush-operator/pkg/nspredicate"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -42,7 +43,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource IOSVariant
-	err = c.Watch(&source.Kind{Type: &pushv1alpha1.IOSVariant{}}, &handler.EnqueueRequestForObject{})
+	onlyEnqueueForValidNamespaces, err := nspredicate.NewFromEnvVar("APP_NAMESPACES")
+	if err != nil {
+		return err
+	}
+	err = c.Watch(
+		&source.Kind{Type: &pushv1alpha1.IOSVariant{}},
+		&handler.EnqueueRequestForObject{},
+		onlyEnqueueForValidNamespaces,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/pushapplication/pushapplication_controller.go
+++ b/pkg/controller/pushapplication/pushapplication_controller.go
@@ -6,6 +6,7 @@ import (
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	"github.com/aerogear/unifiedpush-operator/pkg/controller/util"
+	"github.com/aerogear/unifiedpush-operator/pkg/nspredicate"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +41,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource PushApplication
-	err = c.Watch(&source.Kind{Type: &pushv1alpha1.PushApplication{}}, &handler.EnqueueRequestForObject{})
+	onlyEnqueueForValidNamespaces, err := nspredicate.NewFromEnvVar("APP_NAMESPACES")
+	if err != nil {
+		return err
+	}
+	err = c.Watch(
+		&source.Kind{Type: &pushv1alpha1.PushApplication{}},
+		&handler.EnqueueRequestForObject{},
+		onlyEnqueueForValidNamespaces,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -6,12 +6,14 @@ import (
 
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	"github.com/aerogear/unifiedpush-operator/pkg/config"
+	"github.com/aerogear/unifiedpush-operator/pkg/nspredicate"
+
 	enmassev1beta "github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta1"
 	messaginguserv1beta "github.com/enmasseproject/enmasse/pkg/apis/user/v1beta1"
-	routev1 "github.com/openshift/api/route/v1"
 
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -55,7 +57,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource UnifiedPushServer
-	err = c.Watch(&source.Kind{Type: &pushv1alpha1.UnifiedPushServer{}}, &handler.EnqueueRequestForObject{})
+	onlyEnqueueForServiceNamespace, err := nspredicate.NewFromEnvVar("SERVICE_NAMESPACE")
+	if err != nil {
+		return err
+	}
+	err = c.Watch(
+		&source.Kind{Type: &pushv1alpha1.UnifiedPushServer{}},
+		&handler.EnqueueRequestForObject{},
+		onlyEnqueueForServiceNamespace,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/nspredicate/nspredicate.go
+++ b/pkg/nspredicate/nspredicate.go
@@ -1,0 +1,48 @@
+package nspredicate
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// NewNamespacePredicateFromEnvVar looks up the provided environment
+// variable, parses the value, and returns a NamespacePredicate
+func NewFromEnvVar(envVar string) (NamespacePredicate, error) {
+	namespaces, found := os.LookupEnv(envVar)
+	if !found {
+		return NamespacePredicate{}, fmt.Errorf("Environment variable %s not found", envVar)
+	}
+	return NamespacePredicate{Namespaces: strings.Split(namespaces, ",")}, nil
+}
+
+type NamespacePredicate struct {
+	Namespaces []string
+}
+
+func (p NamespacePredicate) Create(e event.CreateEvent) bool {
+	return p.isValidNamespace(e.Meta.GetNamespace())
+}
+
+func (p NamespacePredicate) Delete(e event.DeleteEvent) bool {
+	return p.isValidNamespace(e.Meta.GetNamespace())
+}
+
+func (p NamespacePredicate) Update(e event.UpdateEvent) bool {
+	return p.isValidNamespace(e.MetaOld.GetNamespace())
+}
+
+func (p NamespacePredicate) Generic(e event.GenericEvent) bool {
+	return p.isValidNamespace(e.Meta.GetNamespace())
+}
+
+func (p NamespacePredicate) isValidNamespace(namespace string) bool {
+	for _, ns := range p.Namespaces {
+		if ns == namespace {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Before this change, we'd try to reconcile a CR in any namespace. This
changes that so that the controller doesn't even bother calling the
Reconcile method if the CR isn't in one of the namespaces that we
expect for that kind.

Since running the operator locally with operator-sdk up local doesn't
seem to correctly react to CRs in namespaces other than one for the
current context, this change also adds that to the list of
APP_NAMESPACES for the `make code/run` target.