### PR TITLE
Tighten permissions in operator ClusterRole

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -3,47 +3,105 @@ kind: ClusterRole
 metadata:
   name: unifiedpush-operator
 rules:
+
+# The resources in this group are the CRs that the controllers in this
+# operator react to. Nothing in the operator is expected to create or
+# delete CRs, so those permissions are not given.
+- apiGroups:
+  - push.aerogear.org
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+
+# For "secondary resources", the operator needs to be able to do
+# pretty much everything. The "deletecollection" permission is the
+# only one not given here (if it needs to delete more than one
+# instance of a kind, it can do them one-by-one.
 - apiGroups:
   - ""
   resources:
-  - pods
   - services
-  - endpoints
   - persistentvolumeclaims
   - events
   - configmaps
   - secrets
   - serviceaccounts
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+
+# Need to be able to check if a namespace is in APP_NAMESPACES
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
+
+# These are needed to be able to run the operator itself
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
   verbs:
   - get
-  - create
 - apiGroups:
   - apps
   resourceNames:
@@ -52,27 +110,16 @@ rules:
   - deployments/finalizers
   verbs:
   - update
+  - patch
 - apiGroups:
-  - push.aerogear.org
+  - ""
   resources:
-  - '*'
+  - pods
   verbs:
-  - '*'
+  - get
 - apiGroups:
-  - image.openshift.io
+  - apps
   resources:
-  - imagestreams
+  - replicasets
   verbs:
-  - '*'
-- apiGroups:
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  verbs:
-  - '*'
-- apiGroups:
-  - batch
-  resources:
-  - cronjobs
-  verbs:
-  - '*'
+  - get


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9616

## Verification Steps

- Check out the branch for this PR
- `make cluster/prepare`
- `kubectl apply -f deploy/operator.yaml`
- Check the operator pod logs to make sure there aren't any errors which could be related to permissions
- `kubectl apply -n unifiedpush -f deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml`
- Check the operator pod logs again to make sure there aren't any errors which could be related to permissions
- Wait for the UPS to become ready

- Create app CRs in the apps namespace, and check the operator pod logs again to make sure there aren't any errors which could be related to permissions.