### PR TITLE
fix(graphana label) : replace daily by Average in the Uptime graph

### DIFF
--- a/deploy/monitor/grafana_dashboard.yaml
+++ b/deploy/monitor/grafana_dashboard.yaml
@@ -149,7 +149,7 @@ spec:
               }
             ],
             "thresholds": "98,99",
-            "title": "Daily Percentage Uptime",
+            "title": "Average Percentage Uptime",
             "transparent": false,
             "type": "singlestat",
             "valueFontSize": "70%",


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9640

## What
Replace the label Daily for Average in the Uptime graphana dash for the operator. 

## Why
- Keep all dashboards equals
- Make more accurate the understanding

