### PR TITLE
fix(Prometheus Alerts): Remove UnifiedPushPodCount since it was considered redundant

### DIFF
--- a/SOP/SOP-operator.adoc
+++ b/SOP/SOP-operator.adoc
@@ -46,24 +46,6 @@ NOTE: The operator is responsible to manage and create all objects required in o
 +
 NOTE: You can save the logs by running `oc logs <operator-podname> > <filename>.log`. The logs may provide you with useful information to lead you to the root cause, and they are also useful for providing to the project maintainers when you create an issue.
 
-== Warning
-
-=== UnifiedPushPodCount
-
-. Switch to the UnifiedPush namespace by running `oc project <namespace>`. E.g `oc project unifiedpush`.
-. Check if it has at least 3 pods (Service, Database and Operator) by running `oc get pods`. The following is an example of the expected result:
-+
-[source,shell]
-----
-$ oc get pods
-NAME                                           READY     STATUS    RESTARTS   AGE
-example-unifiedpushserver-1-dk8vm              2/2       Running   2          9d
-example-unifiedpushserver-postgresql-1-bw8mt   1/1       Running   1          9d
-unifiedpush-operator-58c8877fd8-g6dvr          1/1       Running   3          9d
-----
-+
-NOTE: The operator will keep the number of replicas specified in the DeploymentConfigs for the UnifiedPush Server and its Database in sync with what's specified in the UnifiedPushServer CR.
-
 == Validate
 
 . Check if the operator pod to is present by running `oc get pods | grep operator`. Following an example of the expected result.

--- a/deploy/monitor/prometheus_rule.yaml
+++ b/deploy/monitor/prometheus_rule.yaml
@@ -23,13 +23,3 @@ spec:
           description: "The UnifiedPush Operator has been down for more than 5 minutes. "
           summary: "The UnifiedPush Operator is down. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
           sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc"
-      - alert: UnifiedPushPodCount
-        annotations:
-          description: "The Pod count for the UnifiedPush Server has changed in the last 5 minutes and is lower than the required minimum."
-          summary: "Pod count for namespace UnifiedPush is {{ printf '%.0f' $value }}. Expected 3 pods at least. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc"
-        expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="unifiedpush"})) or sum(kube_pod_status_ready{condition="true", namespace="unifiedpush"}) < 3
-        for: 5m
-        labels:
-          severity: warning


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9642

## What
- Remove UnifiedPushPodCount since it was considered redundant

## Why
According to the convention/standard, we have already the specific rule for each pod. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
