### PR TITLE
Revert "Tighten permissions in operator ClusterRole"

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -3,105 +3,47 @@ kind: ClusterRole
 metadata:
   name: unifiedpush-operator
 rules:
-
-# The resources in this group are the CRs that the controllers in this
-# operator react to. Nothing in the operator is expected to create or
-# delete CRs, so those permissions are not given.
-- apiGroups:
-  - push.aerogear.org
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-
-# For "secondary resources", the operator needs to be able to do
-# pretty much everything. The "deletecollection" permission is the
-# only one not given here (if it needs to delete more than one
-# instance of a kind, it can do them one-by-one.
 - apiGroups:
   - ""
   resources:
+  - pods
   - services
+  - endpoints
   - persistentvolumeclaims
   - events
   - configmaps
   - secrets
   - serviceaccounts
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - batch
-  resources:
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  - '*'
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - image.openshift.io
-  resources:
-  - imagestreams
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-
-# Need to be able to check if a namespace is in APP_NAMESPACES
+  - '*'
 - apiGroups:
   - ""
   resources:
   - namespaces
   verbs:
   - get
-
-# These are needed to be able to run the operator itself
 - apiGroups:
   - apps
   resources:
   - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
   verbs:
   - get
+  - create
 - apiGroups:
   - apps
   resourceNames:
@@ -110,16 +52,27 @@ rules:
   - deployments/finalizers
   verbs:
   - update
-  - patch
 - apiGroups:
-  - ""
+  - push.aerogear.org
   resources:
-  - pods
+  - '*'
   verbs:
-  - get
+  - '*'
 - apiGroups:
-  - apps
+  - image.openshift.io
   resources:
-  - replicasets
+  - imagestreams
   verbs:
-  - get
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - '*'


### PR DESCRIPTION

## Motivation
https://issues.jboss.org/browse/AEROGEAR-9703

## What
This reverts commit 44682e3c3c3b76263f90648d30d39a722b3b4b80.

## Why
It broke at least the Monitoring features and in order to perform changes in the rules, we need do a full regression test to ensure that all features will be still working well after that which could not be done so far. 

## How
git revert --strategy resolve 44682e3c3c3b76263f90648d30d39a722b3b4b80

## Verification Steps
Check all its Prometheus ALerts working well here:

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

 
