### PR TITLE
 Make delete methods in client package idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Adding step checked to solve issue with the Service and Database in the SOP.
+
+## [0.1.1] - 2019-08-06
+### Changed
+- Made delete methods in UPS client package idempotent
+- Added step to the SOP to re-deploy UPS & PostgreSQL
 
 ## [0.1.0] - 2019-07-24
 ### Added

--- a/pkg/controller/unifiedpushserver/fakeclient_test.go
+++ b/pkg/controller/unifiedpushserver/fakeclient_test.go
@@ -3,14 +3,13 @@ package unifiedpushserver
 import (
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
-	imagev1 "github.com/openshift/api/image/v1"
-
 )
 
 //buildReconcileWithFakeClientWithMocks return reconcile with fake client, schemes and mock objects

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller_test.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller_test.go
@@ -1,16 +1,15 @@
 package unifiedpushserver
 
 import (
+	"context"
+	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"testing"
-	"context"
-	openshiftappsv1 "github.com/openshift/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	routev1 "github.com/openshift/api/route/v1"
-	imagev1 "github.com/openshift/api/image/v1"
-
 )
 
 func TestReconcileUnifiedPushServer_Reconcile(t *testing.T) {
@@ -36,7 +35,7 @@ func TestReconcileUnifiedPushServer_Reconcile(t *testing.T) {
 
 	// Check if persistentVolumeClaim has been created
 	persistentVolumeClaim := &corev1.PersistentVolumeClaim{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name+"-postgresql", Namespace: pushServerInstance.Namespace}, persistentVolumeClaim)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name + "-postgresql", Namespace: pushServerInstance.Namespace}, persistentVolumeClaim)
 	if err != nil {
 		t.Fatalf("get persistentVolumeClaim: (%v)", err)
 	}
@@ -50,7 +49,7 @@ func TestReconcileUnifiedPushServer_Reconcile(t *testing.T) {
 
 	// Check if service has been created
 	service := &corev1.Service{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name+"-postgresql", Namespace: pushServerInstance.Namespace}, service)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name + "-postgresql", Namespace: pushServerInstance.Namespace}, service)
 	if err != nil {
 		t.Fatalf("get service: (%v)", err)
 	}
@@ -64,35 +63,35 @@ func TestReconcileUnifiedPushServer_Reconcile(t *testing.T) {
 
 	// Check if service has been created
 	secret := &corev1.Secret{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name+"-postgresql", Namespace: pushServerInstance.Namespace}, secret)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name + "-postgresql", Namespace: pushServerInstance.Namespace}, secret)
 	if err != nil {
 		t.Fatalf("get secret: (%v)", err)
 	}
 
 	// Check if service has been created
 	oauthProxyService := &corev1.Service{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name+"-unifiedpush-proxy", Namespace: pushServerInstance.Namespace}, oauthProxyService)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name + "-unifiedpush-proxy", Namespace: pushServerInstance.Namespace}, oauthProxyService)
 	if err != nil {
 		t.Fatalf("get oauthProxyService: (%v)", err)
 	}
 
 	// Check if service has been created
 	serviceOauth := &corev1.Service{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name+"-unifiedpush-proxy", Namespace: pushServerInstance.Namespace}, serviceOauth)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name + "-unifiedpush-proxy", Namespace: pushServerInstance.Namespace}, serviceOauth)
 	if err != nil {
 		t.Fatalf("get serviceOauth: (%v)", err)
 	}
 
 	// Check if route has been created
 	serviceOauthRoute := &routev1.Route{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name+"-unifiedpush-proxy", Namespace: pushServerInstance.Namespace}, serviceOauthRoute)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name + "-unifiedpush-proxy", Namespace: pushServerInstance.Namespace}, serviceOauthRoute)
 	if err != nil {
 		t.Fatalf("get service Oauth route: (%v)", err)
 	}
 
 	// Check if servicePush has been created
 	servicePush := &corev1.Service{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name+"-unifiedpush", Namespace: pushServerInstance.Namespace}, servicePush)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pushServerInstance.Name + "-unifiedpush", Namespace: pushServerInstance.Namespace}, servicePush)
 	if err != nil {
 		t.Fatalf("get servicePush: (%v)", err)
 	}
@@ -103,7 +102,6 @@ func TestReconcileUnifiedPushServer_Reconcile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get oauthImageStream: (%v)", err)
 	}
-
 
 	// Check if imageStream has been created
 	upsImageStream := &imagev1.ImageStream{}

--- a/pkg/unifiedpush/client.go
+++ b/pkg/unifiedpush/client.go
@@ -126,8 +126,8 @@ func (c UnifiedpushClient) DeleteApplication(p *pushv1alpha1.PushApplication) er
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 204 {
-		return errors.New(fmt.Sprintf("UPS responded with status code: %v, but expected 204", resp.StatusCode))
+	if resp.StatusCode != 204 && resp.StatusCode != 404 {
+		return errors.New(fmt.Sprintf("UPS responded with status code: %v, but expected 204 or 404", resp.StatusCode))
 	}
 
 	return nil
@@ -210,8 +210,8 @@ func (c UnifiedpushClient) DeleteAndroidVariant(v *pushv1alpha1.AndroidVariant) 
 		return err
 	}
 
-	if resp.StatusCode != 204 {
-		return errors.New(fmt.Sprintf("Expected a status code of 204 for variant deletion in UPS, but got %v", resp.StatusCode))
+	if resp.StatusCode != 204 && resp.StatusCode != 404 {
+		return errors.New(fmt.Sprintf("Expected a status code of 204 or 404 for variant deletion in UPS, but got %v", resp.StatusCode))
 	}
 
 	return nil
@@ -309,8 +309,8 @@ func (c UnifiedpushClient) DeleteIOSVariant(v *pushv1alpha1.IOSVariant) error {
 		return err
 	}
 
-	if resp.StatusCode != 204 {
-		return errors.New(fmt.Sprintf("Expected a status code of 204 for variant deletion in UPS, but got %v", resp.StatusCode))
+	if resp.StatusCode != 204 && resp.StatusCode != 404 {
+		return errors.New(fmt.Sprintf("Expected a status code of 204 or 404 for variant deletion in UPS, but got %v", resp.StatusCode))
 	}
 
 	return nil

--- a/test/e2e/unifiedpush_test.go
+++ b/test/e2e/unifiedpush_test.go
@@ -2,8 +2,6 @@ package e2e
 
 import (
 	goctx "context"
-	"testing"
-	"time"
 	apis "github.com/aerogear/unifiedpush-operator/pkg/apis"
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	dcv1 "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
@@ -12,6 +10,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"testing"
+	"time"
 )
 
 var (

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.0"
+	Version = "0.1.1"
 )


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9697

Among other things, this will allow variant CRs to be deleted if they
no longer exist in UPS (which can happen if the PushApplication is
deleted first).

## Verification Steps

Create a PushApplication CR and then an AndroidVariant CR underneath it (use the ID of the PushApplication in the variant CR). Once those are created, first delete the PushApplication CR, and then delete the AndroidVariant CR. The AndroidVariant CR should get deleted successfully, and there shouldn't be any errors.