### PR TITLE
adding resource limits

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,13 @@ spec:
           command:
           - unifiedpush-operator
           imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 60m
+              memory: 128Mi
+            requests:
+              cpu: 30m
+              memory: 64Mi
           env:
             - name: WATCH_NAMESPACE
               value: ""

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -3,6 +3,8 @@ package unifiedpushserver
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	pushv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -270,6 +272,16 @@ func newUnifiedPushServerDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*
 							Image:           cfg.UPSImageStreamName + ":" + cfg.UPSImageStreamTag,
 							ImagePullPolicy: corev1.PullAlways,
 							Env:             buildEnv(cr),
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("2Gi"),
+									"cpu":    resource.MustParse("1"),
+								},
+								Requests: corev1.ResourceList{
+									"memory": resource.MustParse("512Mi"),
+									"cpu":    resource.MustParse("500m"),
+								},
+							},
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          cfg.UPSContainerName,
@@ -313,6 +325,16 @@ func newUnifiedPushServerDeploymentConfig(cr *pushv1alpha1.UnifiedPushServer) (*
 									Name:          "public",
 									Protocol:      corev1.ProtocolTCP,
 									ContainerPort: 4180,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("64Mi"),
+									"cpu":    resource.MustParse("20m"),
+								},
+								Requests: corev1.ResourceList{
+									"memory": resource.MustParse("32Mi"),
+									"cpu":    resource.MustParse("10m"),
 								},
 							},
 							Args: []string{


### PR DESCRIPTION
## Motivation
Set some initial resource limits for ups and the operator.  From this JIRA : https://issues.jboss.org/browse/AEROGEAR-9765?

## What
More or less the limits I set were in line with the suggestions in the JIRA, where they deviate I had found other deployments of the same service that had limits set, or for ups server I tested with lower memory/cpu considerations

## Verification Steps
Standard operator smoke tests should be fine.


## Additional Notes

The limts are fluid right now and we are seeking feedback 