### PR TITLE
Use annotations for storing Ids; reconcile secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.2.0] - 2019-09-05
+### Added
+- `PushApplication`, `AndroidVariant`, and `IOSVariant` all now store
+  their relevant IDs (from UPS) as annotations in their CRs.
+
+### Changed
+- Some values received from UPS (notably `MasterSecret` for
+  `PushApplication`, `Secret` for "variant" kinds), will now be
+  updated in the CR Status if they're "renewed" throught the UPS Admin
+  UI. This update may take some time (next sync interval, since
+  there's no event to trigger immediate reconciliation).
+
+### Deprecated
+- The ID fields in the Status block (`PushApplicationId`, `VariantId`)
+  currently only exist for compatibility, and are likely to be removed
+  in a future version.
+
 ## [0.1.2] - 2019-08-21
 ### Changed
 - Added resource limits for UPS Server, oauthproxy, and postgres pods
@@ -22,4 +40,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PushApplication` kind to create an application in your UPS deployment
 - `AndroidVariant` kind to create an Android variant for an application
 - `IOSVariant` kind to create an iOS variant for an application
-

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.2"
+	Version = "0.2.0"
 )


### PR DESCRIPTION
We previously relied on Ids (from UPS) stored in the Status block of
the CRs, but that led to problems when trying to restore from
backups.

This change doesn't remove the Ids from the Status block, since we
know the MDC relies on them being there for the moment. We should
consider updating that to get it from the annotation, and then no
longer present it in the Status block.

I've also updated some of the reconciliation logic to update the
secrets in the Status block, if someone has performed a "Renew Secret"
through the UPS Admin UI.

----

## Verification Steps

- Deploy this version of the operator to an OpenShift cluster & create a UPS CR (I currently have it deployed, so I can save you some time here)
- Create a PushApplication & verify that the PushApplicationId exists both in the Status block, and as an annotation in `metadata.annotations`
- Grab the PushApplicationId from that, and create Android and iOS Variants. Similarly to the previous step, verify that the VariantId for each is set in the Status block and as an annotation

- From the UPS Admin UI, renew both the master secret for the application, and the secrets on the variants, and notice that they will get updated in the CR Statuses. This may take a while, so I've done something like these commands in 3 different terminals, and just waited until the output changed:

```
while true; do oc get pushapplication example-pushapplication -n unifiedpush-apps -o jsonpath='{.status.masterSecret}' && echo && sleep 10; done
while true; do oc get androidvariant example-androidvariant -n unifiedpush-apps -o jsonpath='{.status.secret}' && echo && sleep 10; done
while true; do oc get iosvariant example-iosvariant -n unifiedpush-apps -o jsonpath='{.status.secret}' && echo && sleep 10; done
```

^while those are running, you could stop/start the operator if you wanted to force the update ;)