### PR TITLE
fix: sender id is set correctly now

### DIFF
--- a/pkg/unifiedpush/client.go
+++ b/pkg/unifiedpush/client.go
@@ -176,7 +176,7 @@ func (c UnifiedpushClient) CreateAndroidVariant(v *pushv1alpha1.AndroidVariant) 
 	url := fmt.Sprintf("%s/rest/applications/%s/android", c.Url, v.Spec.PushApplicationId)
 
 	params := map[string]string{
-		"projectNumber": "1",
+		"projectNumber": v.Spec.SenderId,
 		"name":          v.Name,
 		"googleKey":     v.Spec.ServerKey,
 		"description":   v.Spec.Description,


### PR DESCRIPTION
This fixes https://issues.jboss.org/browse/AEROGEAR-9881

To test this fix create the push app and the android variant using the cr's in the example directory and then confirm that they are set correctly in the UPS console