### PR TITLE
INTLY-3288 - Update Oauth Proxy Image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -409,7 +409,7 @@ environment variable names, along with their default values:
 | Tag of the Oauth proxy image stream that will be created by the operator.
 
 |`OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE`
-|`docker.io/openshift/oauth-proxy:v1.1.0`
+|`quay.io/openshift/origin-oauth-proxy:4.2.0`
 | Initial image for the Oauth proxy image stream that will be created by the operator.
 
 |`POSTGRES_IMAGE_STREAM_NAMESPACE`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,7 +59,7 @@ func New() Config {
 
 		// these are used when the image stream does not exist and created for the first time by the operator
 		UPSImageStreamInitialImage:        getEnv("UPS_IMAGE_STREAM_INITIAL_IMAGE", "quay.io/aerogear/unifiedpush-configurable-container:2.3"),
-		OauthProxyImageStreamInitialImage: getEnv("OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE", "docker.io/openshift/oauth-proxy:v1.1.0"),
+		OauthProxyImageStreamInitialImage: getEnv("OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE", "quay.io/openshift/origin-oauth-proxy:4.2.0"),
 
 		BackupImage: getEnv("BACKUP_IMAGE", "quay.io/integreatly/backup-container:1.0.8"),
 


### PR DESCRIPTION
## Motivation
As part of [INTLY-3288](https://issues.jboss.org/browse/INTLY-3288), when trying to install the UPS operator and verifying it works on a Openshift 4 cluster, an `internal 500 error` was noticed when trying to login via the exposed route. However,  this does not happen on a Openshift 3 cluster.

The error is similar to https://bugzilla.redhat.com/show_bug.cgi?id=1678645 

## What
To resolve this, the `oauth-proxy` image was updated to a later version that supported login through Openshift 4 

## Why
This was done so that the user can successfully login via the exposed UPS route on a Openshift 4 cluster

## How
The image for `oauth-poxy` was update to point to `quay.io/openshift/origin-oauth-proxy:4.2.0`

## Verification Steps
* Using a openshift 4 cluster. install UPS operator using this branch. 
  * `oc login` to cluster
  * `make cluster/prepare`
  * `make code/run`
* After resources have been provisioned, verify that the user can login to UPS via the exposed route without errors
* (Optional Step) - To see error in login, the image tag in the imagestream can be reverted to point back to `docker.io/openshift/oauth-proxy:v1.1.0`
* Repeat for an openshift 3 cluster, to ensure compatability is not broken

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task