### PR TITLE
Aerogear 10074

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 - Operator creates the Monitoring Resources (GrafanaDashboard, PrometheusRule and ServiceMonitor) on creation of the UnifiedPushServer CR.
-- Operator creates its own Monitoring Resrouces (GrafanaDashboard, PrometheusRule) on installation.
+- Operator creates its own Monitoring Resources (GrafanaDashboard, PrometheusRule) on installation.
 - Removal of the templates for the related Monitoring Resources.
 
 ## [0.3.0] - 2019-10-10

--- a/Makefile
+++ b/Makefile
@@ -78,25 +78,6 @@ install:
 	@echo ....... Applying UnifiedPush Server .......
 	- kubectl apply -n $(NAMESPACE) -f deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml
 
-.PHONY: monitoring/install
-monitoring/install:
-	@echo Installing service monitor in ${NAMESPACE} :
-	- oc project ${NAMESPACE}
-	- kubectl label namespace ${NAMESPACE} monitoring-key=middleware
-	- kubectl apply -n $(NAMESPACE) -f deploy/monitor/service_monitor.yaml
-	- kubectl apply -n $(NAMESPACE) -f deploy/monitor/operator_service.yaml
-	- kubectl apply -n $(NAMESPACE) -f deploy/monitor/prometheus_rule.yaml
-	- kubectl apply -n $(NAMESPACE) -f deploy/monitor/grafana_dashboard.yaml
-
-.PHONY: monitoring/uninstall
-monitoring/uninstall:
-	@echo Uninstalling monitor service from ${NAMESPACE} :
-	- oc project ${NAMESPACE}
-	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/service_monitor.yaml
-	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/prometheus_rule.yaml
-	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/grafana_dashboard.yaml
-	- kubectl delete -n $(NAMESPACE) -f deploy/monitor/operator_service.yaml
-
 .PHONY: example-pushapplication/apply
 example-pushapplication/apply:
 	@echo ....... Applying the PushApplication example in the current namespace  ......
@@ -139,7 +120,6 @@ cluster/clean:
 	- kubectl delete -f deploy/crds/push_v1alpha1_iostokenvariant_crd.yaml
 	- kubectl delete -f deploy/crds/push_v1alpha1_iosvariant_crd.yaml
 	- kubectl delete -f deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
-	- make monitoring/uninstall
 	- kubectl delete namespace $(NAMESPACE)
 	- kubectl delete namespace $(APP_NAMESPACE)
 

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -983,7 +983,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	serviceMonitor := &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Name: "unifiedpush", Namespace: instance.Namespace}}
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, serviceMonitor, func(ignore runtime.Object) error {
 		reconcileServiceMonitor(serviceMonitor)
-		return nil
+		// Set UnifiedPushServer instance as the owner and controller
+		err := controllerutil.SetControllerReference(instance, serviceMonitor, r.scheme)
+		return err
 	})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -997,7 +999,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	prometheusRule := &monitoringv1.PrometheusRule{ObjectMeta: metav1.ObjectMeta{Name: "unifiedpush", Namespace: instance.Namespace}}
 	op, err = controllerutil.CreateOrUpdate(context.TODO(), r.client, prometheusRule, func(ignore runtime.Object) error {
 		reconcilePrometheusRule(prometheusRule, instance)
-		return nil
+		// Set UnifiedPushServer instance as the owner and controller
+		err := controllerutil.SetControllerReference(instance, prometheusRule, r.scheme)
+		return err
 	})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -1011,7 +1015,9 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 	grafanaDashboard := &integreatlyv1alpha1.GrafanaDashboard{ObjectMeta: metav1.ObjectMeta{Name: "unifiedpushserver-dashboard", Namespace: instance.Namespace}}
 	op, err = controllerutil.CreateOrUpdate(context.TODO(), r.client, grafanaDashboard, func(ignore runtime.Object) error {
 		reconcileGrafanaDashboard(grafanaDashboard, instance)
-		return nil
+		// Set UnifiedPushServer instance as the owner and controller
+		err := controllerutil.SetControllerReference(instance, grafanaDashboard, r.scheme)
+		return err
 	})
 	if err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-10074

## What
Applying feedback from [](https://github.com/aerogear/unifiedpush-operator/pull/83)

## Verification Steps
`make install`
Verify that the operator monitoring resources have the service as an owner reference entry
Verify that the service monitoring resources have the UnifiedPushServer instance/cr as an owner reference
 `oc delete -f deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml`
Verify that the UnifiedPushServer owned GrafanaDashboard, PrometheusRule and ServiceMonitor are cleaned up.
`oc delete -f deploy/operator.yaml`
Verify that the opearator owned GrafanaDashboard, PrometheusRule and ServiceMonitor are cleaned up.

**Cleanup**
`make cluster/clean` 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Additional Notes

Image: quay.io/aerogear/unifiedpush-operator:dde4a2e
 
