### PR TITLE
expose node affinity and tolerations to the ups and postgres deployments

### DIFF
--- a/deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
+++ b/deploy/crds/push_v1alpha1_unifiedpushserver_crd.yaml
@@ -31,6 +31,8 @@ spec:
           type: object
         spec:
           properties:
+            affinity:
+              type: object
             backups:
               description: Backups is an array of configs that will be used to create
                 CronJob resource instances
@@ -115,6 +117,10 @@ spec:
               type: string
             postgresResourceRequirements:
               type: object
+            tolerations:
+              items:
+                type: object
+              type: array
             unifiedPushResourceRequirements:
               type: object
             useMessageBroker:

--- a/pkg/apis/push/v1alpha1/unifiedpushserver_types.go
+++ b/pkg/apis/push/v1alpha1/unifiedpushserver_types.go
@@ -51,6 +51,9 @@ type UnifiedPushServerSpec struct {
 
 	// PVC size for Postgres service
 	PostgresPVCSize string `json:"postgresPVCSize,omitempty"`
+
+	Affinity    *corev1.Affinity    `json:"affinity,omitempty"`
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // UnifiedPushServerStatus defines the observed state of UnifiedPushServer

--- a/pkg/apis/push/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/push/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -114,6 +115,18 @@ func (in *UnifiedPushServerSpec) DeepCopyInto(out *UnifiedPushServerSpec) {
 	in.UnifiedPushResourceRequirements.DeepCopyInto(&out.UnifiedPushResourceRequirements)
 	in.OAuthResourceRequirements.DeepCopyInto(&out.OAuthResourceRequirements)
 	in.PostgresResourceRequirements.DeepCopyInto(&out.PostgresResourceRequirements)
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
+		*out = new(v1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/push/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/push/v1alpha1/zz_generated.openapi.go
@@ -128,11 +128,28 @@ func schema_pkg_apis_push_v1alpha1_UnifiedPushServerSpec(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"affinity": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.Affinity"),
+						},
+					},
+					"tolerations": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.Toleration"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1.UnifiedPushServerBackup", "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1.UnifiedPushServerDatabase", "k8s.io/api/core/v1.ResourceRequirements"},
+			"github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1.UnifiedPushServerBackup", "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1.UnifiedPushServerDatabase", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration"},
 	}
 }
 

--- a/pkg/controller/unifiedpushserver/backups.go
+++ b/pkg/controller/unifiedpushserver/backups.go
@@ -45,6 +45,8 @@ func backups(ups *pushv1alpha1.UnifiedPushServer) ([]batchv1beta1.CronJob, error
 									},
 								},
 								RestartPolicy: corev1.RestartPolicyOnFailure,
+								Affinity:      ups.Spec.Affinity,
+								Tolerations:   ups.Spec.Tolerations,
 							},
 						},
 					},

--- a/pkg/controller/unifiedpushserver/postgresql.go
+++ b/pkg/controller/unifiedpushserver/postgresql.go
@@ -169,6 +169,8 @@ func newPostgresqlDeployment(cr *pushv1alpha1.UnifiedPushServer) (*appsv1.Deploy
 							},
 						},
 					},
+					Affinity:    cr.Spec.Affinity,
+					Tolerations: cr.Spec.Tolerations,
 					Volumes: []corev1.Volume{
 						{
 							Name: fmt.Sprintf("%s-postgresql-data", cr.Name),

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -291,6 +291,8 @@ func newUnifiedPushServerDeployment(cr *pushv1alpha1.UnifiedPushServer) (*appsv1
 							},
 						},
 					},
+					Affinity:    cr.Spec.Affinity,
+					Tolerations: cr.Spec.Tolerations,
 				},
 			},
 		},

--- a/pkg/controller/unifiedpushserver/util.go
+++ b/pkg/controller/unifiedpushserver/util.go
@@ -51,6 +51,14 @@ func findContainerSpec(deployment *appsv1.Deployment, name string) *corev1.Conta
 	return nil
 }
 
+func findPodSpec(deployment *appsv1.Deployment) *corev1.PodSpec {
+	if deployment == nil || &deployment.Spec == nil || &deployment.Spec.Template == nil || &deployment.Spec.Template.Spec == nil {
+		return nil
+	}
+
+	return &deployment.Spec.Template.Spec
+}
+
 func updateContainerSpecImage(deployment *appsv1.Deployment, name string, image string) {
 	if deployment == nil || &deployment.Spec == nil || &deployment.Spec.Template == nil || &deployment.Spec.Template.Spec == nil || &deployment.Spec.Template.Spec.Containers == nil || len(deployment.Spec.Template.Spec.Containers) == 0 {
 		return


### PR DESCRIPTION
## Motivation

Expose node affinity and tolerations to all UPS related pods (ups server, database, backup pods), so that we can control the nodes it gets scheduled on.

## What

Add `NodeAffinity` and `Toleratios` to the UPS CR.

## Why

To be able to schedule UPS on specific nodes (infra in the case of RHMI).

## Verification Steps

1. Deploy UPS using the operator
2. Once successful, edit the UnifiedPushServer CR and add this to the spec:
```
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
        - matchExpressions:
            - key: node-role.kubernetes.io/infra
              operator: In
              values:
                - ""
tolerations:
  - key: "node-role.kubernetes.io/infra"
    operator: "Exists"
    effect: "PreferNoSchedule"
```
3. all ups pods should get redeployed. They may end up being not schedulable depending on the taints that the nodes have.


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

