### PR TITLE
fix: adding the v in version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.5.0"
+	Version = "v0.5.0"
 )


### PR DESCRIPTION
## Motivation
See INTLY-8590

## What
The version field needs to match the version tag for purposes of linking. 

## Why
The wrong version tag was causing incorrect links to be generated

## Verification Steps
This will have to be tested when a new release is made.

1. Deploy the operator
2. Make sure the links in the Prometheus monitor work.

