### PR TITLE
Aerogear 10281 sop restart

### DIFF
--- a/SOP/SOP-push.adoc
+++ b/SOP/SOP-push.adoc
@@ -507,21 +507,23 @@ NOTE: You can save the logs by running `oc logs <database-podname> > <filename>.
 This alert indicates that the Service pod(s) is/are facing performance issues.
 
 . Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
-. Following the steps <<To scale the pod>> in order to try to solve performance issues.
+. Restart the affected pod if the heap memory usage is still higher than the threshold.
+
 
 ==== UnifiedPushJavaNonHeapThresholdExceeded
 
 This alert indicates that the Service pod(s) is/are facing performance issues.
 
 . Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
-. Following the steps <<To scale the pod>> in order to try to solve performance issues.
+. Restart the affected pod if the nonheap memory usage is still higher than the threshold.
+
 
 ==== UnifiedPushJavaGCTimePerMinuteScavenge
 
 This alert indicates that the Service pod(s) is/are facing performance issues.
 
 . Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
-. Following the steps <<To scale the pod>> in order to try to solve performance issues.
+. Restart the affected pod if the garbage collector usage is still higher than the threshold.
 
 === Warning
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.5.0"
+	Version = "v0.5.0"
 )


### PR DESCRIPTION
## Motivation
The current SOP instructs troubleshooters to scale pods during periods of memory pressure. This is incorrect the the affected pod should be restarted.

## What
The SOP removed the instructions to scale the pod and replaced them with instructions to rebstart the pod based on the AMQ SOP

## Why
UPS is not scalable and the instructions were wrong and not helpful.



## Verification Steps
Docs only, no technical verification.