### PR TITLE
intly-8601 remove alert UnifiedPushJavaHeapThresholdExceeded

### DIFF
--- a/SOP/SOP-push.adoc
+++ b/SOP/SOP-push.adoc
@@ -502,13 +502,6 @@ NOTE: You can save the logs by running `oc logs <database-podname> > <filename>.
 . Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/unifiedpush-operator/blob/0.1.2/SOP/SOP-operator.adoc[UnifiedPushOperatorDown]
 . In order to fix it, try to deploy it again by running `oc rollout --latest dc/unifiedpush-postgresql`
 
-==== UnifiedPushJavaHeapThresholdExceeded
-
-This alert indicates that the Service pod(s) is/are facing performance issues.
-
-. Please following the <<To capture the logs>> procedure in order to capture the required information to send it to its maintainers.
-. Following the steps <<To scale the pod>> in order to try to solve performance issues.
-
 ==== UnifiedPushJavaNonHeapThresholdExceeded
 
 This alert indicates that the Service pod(s) is/are facing performance issues.

--- a/pkg/controller/unifiedpushserver/unifiedpushserver.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver.go
@@ -356,11 +356,6 @@ func reconcilePrometheusRule(prometheusRule *monitoringv1.PrometheusRule, cr *pu
 		"summary":     "The aerogear-unifiedpush-server Database is down.",
 		"sop_url":     sop_url,
 	}
-	unifiedPushJavaHeapThresholdExceededAnnotations := map[string]string{
-		"description": "The Heap Usage of the aerogear-unifiedpush-server Server exceeded 90% of usage.",
-		"summary":     "The aerogear-unifiedpush-server Server JVM Heap Threshold Exceeded 90% of usage.",
-		"sop_url":     sop_url,
-	}
 	unifiedPushJavaNonHeapThresholdExceededAnnotations := map[string]string{
 		"description": "The nonheap usage of the aerogear-unifiedpush-server Server exceeded 90% of usage.",
 		"summary":     "The nonheap usage of the aerogear-unifiedpush-server Server exceeded 90% of usage.",
@@ -408,16 +403,6 @@ func reconcilePrometheusRule(prometheusRule *monitoringv1.PrometheusRule, cr *pu
 						For:         "5m",
 						Labels:      critical,
 						Annotations: unifiedPushConsoleDownAnnotations,
-					},
-					{
-						Alert: "UnifiedPushJavaHeapThresholdExceeded",
-						Expr: intstr.IntOrString{
-							Type:   intstr.String,
-							StrVal: fmt.Sprintf("100 * jvm_memory_bytes_used{area=\"heap\",namespace=\"%s\"}/ jvm_memory_bytes_max{area=\"heap\",namespace=\"%s\"}> 90", namespace, namespace),
-						},
-						For:         "1m",
-						Labels:      critical,
-						Annotations: unifiedPushJavaHeapThresholdExceededAnnotations,
 					},
 					{
 						Alert: "UnifiedPushJavaNonHeapThresholdExceeded",


### PR DESCRIPTION
## Motivation
JIRA - https://issues.redhat.com/browse/INTLY-8601

## What
Removes UnifiedPushJavaHeapThresholdExceeded Alert

## Why
Based on a discussion over INTLY-8601 it was decided to remove the alert to reduce toil on SRE

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run the Operator
2. Add `oc apply -f deploy/crds/push_v1alpha1_unifiedpushserver_cr.yaml -n unifiedpush`
3. Run `oc get prometheusrules unifiedpush  -n unifiedpush -o yaml`
4. Ensure `UnifiedPushJavaHeapThresholdExceeded` does not exist

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

 
