### PR TITLE
chore: update backup-container to 1.0.16

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,5 +4,5 @@ const (
 	UPSImage        = "quay.io/aerogear/unifiedpush-configurable-container:2.3.2-1"
 	PostgresImage   = "centos/postgresql-10-centos7:1"
 	OauthProxyImage = "quay.io/openshift/origin-oauth-proxy:4.2.0"
-	BackupImage     = "quay.io/integreatly/backup-container:1.0.8"
+	BackupImage     = "quay.io/integreatly/backup-container:1.0.16"
 )


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-10332

## What
Update the backup-container to the latest version

