### PR TITLE
Prepare v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [0.5.1] - 2021-8-9
+### Changed
+- Alerts updated to support Openshift 4.8.
+
 ## [0.5.0] - 2020-01-12
 ### Added
 - New field databaseSecret to UnifiedPushServer CRD spec.

--- a/deploy/olm-catalog/unifiedpush-operator/0.5.1/push_v1alpha1_unifiedpushserver_crd.yaml
+++ b/deploy/olm-catalog/unifiedpush-operator/0.5.1/push_v1alpha1_unifiedpushserver_crd.yaml
@@ -1,0 +1,163 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: unifiedpushservers.push.aerogear.org
+spec:
+  group: push.aerogear.org
+  names:
+    kind: UnifiedPushServer
+    listKind: UnifiedPushServerList
+    plural: unifiedpushservers
+    shortNames:
+    - ups
+    singular: unifiedpushserver
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            affinity:
+              type: object
+            backups:
+              description: Backups is an array of configs that will be used to create
+                CronJob resource instances
+              items:
+                properties:
+                  backendSecretName:
+                    description: BackendSecretName is the name of a secret containing
+                      storage backend details, such as "AWS_S3_BUCKET_NAME", "AWS_ACCESS_KEY_ID",
+                      and "AWS_SECRET_ACCESS_KEY"
+                    type: string
+                  backendSecretNamespace:
+                    description: BackendSecretNamespace is the name of the namespace
+                      that the secret referenced in BackendSecretName resides in
+                    type: string
+                  encryptionKeySecretName:
+                    description: EncryptionKeySecretName is the name of a secret containing
+                      PGP/GPG details, including "GPG_PUBLIC_KEY", "GPG_TRUST_MODEL",
+                      and "GPG_RECIPIENT"
+                    type: string
+                  encryptionKeySecretNamespace:
+                    description: EncryptionKeySecretNamespace is the name of the namespace
+                      that the secret referenced in EncryptionKeySecretName resides
+                      in
+                    type: string
+                  name:
+                    description: Name is the name that will be given to the resulting
+                      CronJob
+                    type: string
+                  schedule:
+                    description: Schedule is the schedule that the job will be run
+                      at, in cron format
+                    type: string
+                required:
+                - name
+                - schedule
+                - backendSecretName
+                type: object
+              type: array
+            database:
+              description: Database allows specifying the external PostgreSQL details
+                directly in the CR. Only one of Database or DatabaseSecret should
+                be specified, and ExternalDB must be true, otherwise a new PostgreSQL
+                instance will be created (and deleted) on the cluster automatically.
+              properties:
+                host:
+                  description: Host for external database support
+                  type: string
+                name:
+                  description: Name for external database support
+                  type: string
+                password:
+                  description: Password for external database support
+                  type: string
+                port:
+                  anyOf:
+                  - type: string
+                  - type: integer
+                  description: Port for external database support
+                user:
+                  description: User for external database support
+                  type: string
+              type: object
+            databaseSecret:
+              description: 'DatabaseSecret allows reading the external PostgreSQL
+                details from a pre-existing Secret (ExternalDB must be true for it
+                to be used). Only one of Database or DatabaseSecret should be specified,
+                and ExternalDB must be true, otherwise a new PostgreSQL instance will
+                be created (and deleted) on the cluster automatically.  Here''s an
+                example of all of the fields that the secret must contain:  POSTGRES_DATABASE:
+                sampledb POSTGRES_HOST: 172.30.139.148 POSTGRES_PORT: "5432" POSTGRES_USERNAME:
+                userMSM POSTGRES_PASSWORD: RmwWKKIM7or7oJig POSTGRES_SUPERUSER: "false"
+                POSTGRES_VERSION: "10"'
+              type: string
+            externalDB:
+              description: ExternalDB can be set to true to use details from Database
+                and connect to external db
+              type: boolean
+            oAuthResourceRequirements:
+              type: object
+            postgresPVCSize:
+              description: PVC size for Postgres service
+              type: string
+            postgresResourceRequirements:
+              type: object
+            tolerations:
+              items:
+                type: object
+              type: array
+            unifiedPushResourceRequirements:
+              type: object
+            useMessageBroker:
+              description: UseMessageBroker can be set to true to use managed queues,
+                if you are using enmasse. Defaults to false.
+              type: boolean
+          type: object
+        status:
+          properties:
+            message:
+              description: Message is a more human-readable message indicating details
+                about current phase or error.
+              type: string
+            phase:
+              description: Phase indicates whether the CR is reconciling(good), failing(bad),
+                or initializing.
+              type: string
+            ready:
+              description: Ready is True if all resources are in a ready state and
+                all work is done (phase should be "reconciling"). The type in the
+                Go code here is deliberately a pointer so that we can distinguish
+                between false and "not set", since it's an optional field.
+              type: boolean
+            secondaryResources:
+              additionalProperties:
+                items:
+                  type: string
+                type: array
+              description: 'SecondaryResources is a map of all the secondary resources
+                types and names created for this CR.  e.g "Deployment": [ "DeploymentName1",
+                "DeploymentName2" ]'
+              type: object
+          required:
+          - phase
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/unifiedpush-operator/0.5.1/unifiedpush-operator.v0.5.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/unifiedpush-operator/0.5.1/unifiedpush-operator.v0.5.1.clusterserviceversion.yaml
@@ -1,0 +1,236 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"push.aerogear.org/v1alpha1","kind":"UnifiedPushServer","metadata":{"name":"example-unifiedpushserver"},"spec":{"useMessageBroker":false}},{"apiVersion":"push.aerogear.org/v1alpha1","kind":"UnifiedPushServer","metadata":{"name":"example-ups-with-backups"},"spec":{"backups":[{"backendSecretName":"example-aws-key","backendSecretNamespace":"unifiedpush","encryptionKeySecretName":"example-encryption-key","encryptionKeySecretNamespace":"unifiedpush","name":"ups-daily-at-midnight","schedule":"0
+      0 * * *"}]}},{"apiVersion":"push.aerogear.org/v1alpha1","kind":"UnifiedPushServer","metadata":{"name":"ups-with-enmasse"},"spec":{"useMessageBroker":true}},{"apiVersion":"push.aerogear.org/v1alpha1","kind":"UnifiedPushServer","metadata":{"name":"example-unifiedpushserver"},"spec":{"database":{"host":"example-host","name":"example-name","password":"password","port":5432,"user":"user"},"externalDB":true,"useMessageBroker":false}},{"apiVersion":"push.aerogear.org/v1alpha1","kind":"UnifiedPushServer","metadata":{"name":"example-unifiedpushserver"},"spec":{"databaseSecret":"ext-postgresql","externalDB":true,"useMessageBroker":false}},{"apiVersion":"push.aerogear.org/v1alpha1","kind":"UnifiedPushServer","metadata":{"name":"example-unifiedpushserver"},"spec":{"oAuthResourceRequirements":{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"postgresPVCSize":"10Gi","postgresResourceRequirements":{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"1","memory":"1Gi"}},"unifiedPushResourceRequirements":{"limits":{"cpu":"2","memory":"3Gi"},"requests":{"cpu":"1","memory":"1Gi"}}}}]'
+    capabilities: Basic Install
+  name: unifiedpush-operator.v0.5.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents an AeroGear UnifiedPush Server
+      displayName: UnifiedPush Server
+      kind: UnifiedPushServer
+      name: unifiedpushservers.push.aerogear.org
+      version: v1alpha1
+  description: The UnifiedPush Operator for Kubernetes provides an easy way to install
+    and manage an AeroGear UnifiedPush Server on OpenShift.
+  displayName: UnifiedPush Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAACXBIWXMAABYlAAAWJQFJUiTwAAAVBklEQVR4nO2dfWyV133Hv+deG2OCY/MyAgTHbmCRyYviKKwNajfcTUqkSRNGCorS/WGzalX/2WSWSlPVpJClVdsp2Zz9s0rTFPNPt5RJwDptTaQOI7UNaohiWha8qAl27MJKeDM2+PXeM/2uz4Hre57n3uf97f4+0hXwnGvuvY/98e/lnOc8QkoJJlhGO0QbgG4Aneqh/w3198c9vuBZADfU30fU38fUY6RrXN4wvoLxBQvik9EO0aN++LUQe2J+S6e0MEqaYeMZjGNYEBeMdggSoEc9un1Egqg5q4QhWYa7xuVYSt537LAgVVCpEsnQq/7ssH92qhhXshxXwnBqZgMLUoGKElqIvcYTsskJLQxHl5WwIHcjBUkxkKK0KSwoHRtUstR9ZKlrQUY7BEnRX0eRwi0UWYa6xuXxdL3t4Kg7QVQK1a8eWakpwoZqliElS12lYHUjyGiH6FYpVJ8xyLjhCKVgXeNypB7OWuYFUfMUhxMwP5E1aL7lcNbnWTIrCIsRGZkWJXOCsBixkUlRMiOIKr4HuSMVO9T5GshKMZ96QdQcBhXfh4xBJk5eVsV8qudSUi2ImscY5HZtYhlX0SS18yipFESlU0NcZ6QGqk/605h25YwjCWe0QwyolaksR3qg79WI+t6litREEI4amSFV0SQVEUTVGhw1soGOJr1p+DSJjiCqQzXIy0MyyxFVxCe205VYQdTaqSFefp55zqqUK5FruxKZYqnwO8xy1AX0PR5OasqVOEFGOwQtEzkGoNUYZLIKfa+Pqe99okhMisX1BqNIVF2SCEGUHJxSMRqqS3qSIEnsKZaa32A5mHJ0XdIZ91mJNYKoTtUw1xuMDVMqksTW4YotgrAcjANaVSTpjutkxSIIy8G4IFZJIheE5WA80DpTxOkz7eK5qE9epDUIy8F4YboAzElAAHJ1Ds/vmpBvRnUiI4sgLAfjBS0HQY7MFfEvUUaSSCKIateNsByMG8rlKIciSXMOf/DkhPypMRgwoUcQNQl4nOVg3GAnB1QkmZd4+712Efql1qEKwjPkjBeqyaEpSDTPS5wPW5KwI8ggy8G4wYkcGpJkSeInxkCAhCaIWpnJCw8Zx7iRQ7Mgsf0X20Rom9WFIoha28/7VDGO8SKHZl5iz5l28R1jIAAC72JxOzcd5O9tw5rdPWh6uBurH+5G7t425Fvb0LTzbkZ8+/Sp0p+Lk2Olx+13hjH/wQgKN4NdZOtHDk1YcySBCsJFebJp3NaJ9V8eWBZjp/dv0fz5s5g6OoTpt46XxPFDEHJo8gKzTQI7n5yQ48agR4IWZIjrjuTRur8frc/2Y81TwW8KM/P2CVz750HcPu2+DAhSDs0qgY8+Nyl3GAMeCUwQVXccMwaY2Gh5phebDg2i8f7wd2aldOzK3x92LEoYcmiac/jurgn5dWPAA4EIwjPlyYJSqS2vDYUSMWpBEeXSC/1V65Qw5UDAM+1BdbGGWI5kQOnUZ348EoscxNqn92L7z8ew5qkeYwwRyAE1074g8SNjwAO+BVH7rfKOhwmAosaWV99AriXe31X0+g+8eRIbD67cpCQKOTRLEm3vbhO+U35fKRanVsmAWrYP/HDYV2cqLKb+7Ugp5YpSDk0QqZbfCMKpVcwkWQ6i9dk+bHx1KHI5EFCq5VkQ1bXi1CpmkiyHZuP+Pjw0OGQcjwJKtfzMsnsSpGyTNyZGqOZIuhya+/b3oeOFeDZOnC/ia15X/XqNIAN827N4oRlxSl/SxAN/dQitu627W2FSBBoKsrRjo2tcF+mqML9gDDCRQfMc1MqNu1vlhaXpKbz72U4sVZknCYs1Ofy+24LdSwTh1CpmKLVKoxxEQ0srHvybeH6EFiWOGgdr4CqCqJv0nzQGmMigiUCa6wiSGzduYGRkBMPD5jKRnp4edHd3o62tzRjzwy+f/SKm3jFfL2yaczi4a0I6NtStIMPcuYoXmqUOam3V0NAQBgcHcfbsWWOskscffxyHDx9Gb28wt/GYeucUfvls9PVIg8CN3ZNynTFgg+MUS0UPliNGKHoEIcfx48fR2dmJAwcOOJKDoOft27evJAhFHL+07t4TS8Gu2r6O77brpgZJ3M1N6o3KpRte6O/vL/2gj497u2TixIkTpf8jCO7/83juCr0onV/t6kgQjh7xQ1f9+Y0e9IN95IinbucKSBKresUtG57Zi4Z7g61tnOAmijiNIBw9YobSK79QwV2Njo4O7Nmz586D/m0H1S9BcN9zwUQjtziNIjUFUdeYc/SImbXP+C+OKYIcOmT+XPT19eH999/H2NhYKTLoB/37jTesO2Y0FgRx1CG4G0VqbmHqJILEkygyd6CJwaA6V9SJIiGgOlMkBkUDauVaQVJRNAkLSrPioiDx7Vov3WAcKUPNmqf6GnO7C3eSRGFVE4q3ZmzfUcsf/rFxzA86PaIWr5P5Dep4nTp1yjgeFBRF4pgToT213msXX6g2u15VEPoFYhxJAZSv01qltCzk+/TTT41j5axdu9Y45henNQS1dKktHCZrH+2ORRAsR5FvUXlmDChqpVipEoQ6PbRGiWaa0yLH4uKicayShoZav8fCgSSi6DE1NWX8/0FNGBJN2+K7V+eixOeNg2XYCqKu90jNil2SIw3XRnhBCBHZa1HEoNRLTyRayUHdraDmQoi1j1jXP1FAK32rXS9iK0iaooe+qi6NC/iKxaJxrJKoIogu1g8ePFh1ItFp7ZIWlqT9z7qlIOqCqPjaCy6hvZ/Surp1dvwj41jU0EJFEoMiRjUxWltbS12vINOrJLAosdnugipLQSjFNI4kFIoeabtwKElQ1HjiiSdqrsnau3dvae7Drh2cdorAS1YfwU6Q1Mx9BDGBVq8MDAyUokY1SIyTJ0+WOllZSqsqWZT4knHQShA195GaSrcxxg5IEDR3bI/ldSlyvP7668ZxDU0mXrhwoSRGrSUqWYBuxkNzIpUfxar641/JEZLLGb+jDJaWlgIt1GkZiV3koA4VyVMPUlRSlHgBwIpJQ6vvTv2dmYQT9D1c7Fq0lE5RwR61HDP/M2Ici4MC8FTly64QJG3dqyzgJDJQBAkKig5WnSpal0VjcdQZ8z7vMRIUVt2sygjC0SNiSpOAc7NVXzRIQWgOw4o4i/CZc8mIIFjejfGr5f+u/PXF9Ucc3LwOrG62feGgBKH0ya6da5d2VSOIi6ZQuj49nnVYVhQk9gO4c2+RSkE4gsRAY9NqVFuRRYIUCgXk83ljzA3VfqDDXK1bDdq8IUksSVinWKq9azmbyIRLc3vtVvXsjP1yeKcEdZFTkFx9K9yVwm6htVnl7d7yGoSjR0ysWrWq6gvPXLuCiYsXjeNuoRQraVz9cbIEwbIkd/JNFiQBUKEurl62fCMkx/Vbs5idncXCwoIxnmauvnUCcxPJi2pFedeF8hokm4tsUsLqtjZU9rK0HJpLly5V3UihFtTBCmJPq6D4zT9Zd9TipgBs1W+hXBC+t3mM3HPfVsxeuXLnDVTKQVy9ehVbtmypmZLZkaSFhlScJ6l7VQ4tO9H/LKVYat8rJkYozcpfW06zrOTQUBTJAuOvJXsnKb1vlq5BOL1KAC0PPoSZ69ds5YCKIjMBdLTi5LdHjyQ2emikXN7qigVJEEu3ZjB7tfoGDsTExIRxLDWfcXoKH38z+VdTFIHHUCZIuteMZ4DZG9cxs7iEe53MiczOYnJy0jieBj440BvLzXPcUgQ2oEwQ3jkxRrQcRFNTExpnbtZ8M5cvXy6lW2nik797OfGplYZ2XqS/5tQKXiYmyuXQbNjxkKM3Q1GEokkaoLoj6YV5JbSyN8f1R3xYyUE0NjaixepKnQpofdaHH36YeElIjg8H0rcHoQT25bj+iAc7OTRt97ej4da0cbySpEuSVjmwLMijLEgM1JJDs3H770LMzxnHKyFJzp8/n7iahGqOtMqB5VbvDppJ5xokQpzKAZVqta1fV3VepBy6UpAiCc22+10a7wdq5ZIYSVyI6AYJtHINEiFu5NCsXb8R9yw5X6RI3S2KJnFNJtICRLoPetrlwHKrt9PLfdIZD3iRQ7P+M9vRXKh2SdVKaNUv1SUUUaJaAbx819ov4oM/S8c8h1M4xYoAP3JoNnY+iCtjH2M232iM2UE1CT02bNiATZs2obnZ/rJer5AY1L5Ny/yGGyTQ1MCreMMlCDk0JMmnYx9jzoUkKBOFBCFZaHMGryuCiVsfnMVvfzhUSqOSeD1HUNCq3nhuPFEnBCmH5nc8SoKyJSr0IEHWrFlTkqalpaU0TsfKxaH0jB7UJbs19hFu/MMrmPr5cKZSqFqwICERhhwakqS0JP7adaBptTHuBP3DTxdQOVlCXzj3HuYyUHi7hYv0EAhTDg11tzZ3dCLnYDKR8Q4LEjBRyKGheZItD3VhLX8XQ4NPbYBEKYeGNr9ed387Nm/ejLyDVcCMy/NrHGE8EYcc5VA02brzkVI7l0UJDhYkAOKWoxy6nkSLsmq6frpNYcFdLJ8kSY5ySJT7Hn6sdJPQ2zeuYfrib7DUut54HlMdFsQHSZWjHKpRqONFD5Jlfn4et8Y/xgLt99t8D7CqyfgaK3L03DqEBfFIGuSohGShicHmrkdWjCwuLla9HTXVN3OXJ/CJMZJ9WBAPpFGOapAAjDVcpLska3Iw1WFBXMBy1B8kiPUth5gVsBz1R15glgThZnkNWI76RADznGLVgOWob0iQ5N12KCGwHPVNDhjjFMsGloMRwBQJkt1rJj3CcjAo3bMFv2ZBKmA5GI0AznENUgbLwZQjgGO5rnHJNQjLwVjw5IQc123eU+Zw/cByMJU0iOXmlRakbusQloOxIgeUdgLXgtRlHcJyMHbkgF+hngVhOZhqCLFcdpQE6RqX2dtYtQosB1OLXRNyEBXL3etiVS/LwdSCVvHqp5QLkvk0i+VgnJAHLuqnlQuS6TSL5WCckhN3XagLQVgOxg05YEg//Y4gXeOS5kLGs3YmWQ7GDTlg6ckJ+VP9JZUXTGUqirAcjFsaxMogUSlIZm4AwXIwXsgLHC3/skxGEJaD8YoAvl/+pSsEUSt7T6T57LIcjFcaBf6PVvCWf7nVpg2pjSIsB+OHPHC68sutBEllHcJyMH7JCbxW+V8Ygqh2b6qWnbAcjF9oeUl5e1djCKIYNI4klOKGTSwH45tGgR9Y/R92gqQmzZr75IJxjGHckgNesfoSS0Gy0M1iGKdYda80loIohowjDJNBGoT9z7qtIF3j8ngW12YxTDm09mrXhPy63UmxFURhaxbDZIFGgZ9V+xgsCFPX5AVerPb5qwqi5kSOGAMMkwFWCXxkNffhWBBFauZEGMYNeYFv1Hp6TUG6xuVIve+8yGQP2jlx14R8s9YHc3qHqcPGEYZJMY0CLzt5944EUftmJTKKFC5NGMeY4Fm8mJ3zrKKHo9LBzT0KExlFFob/yzjGBM/Mf/9nZs6q0+gBN4IkNYrI6SnM/0fNVJLxweKlSUyfzMYvIjfRAy4jCJIaRW699iLkzE3jOBMMl176i8ycSTfRA24FUVEkcYsYKYrc/EoviixJ4Fz65l/i9pmqk82pgRYluoke8BBBiAHjSAK4fv4cPvlybykdYPxDv2xIjql//9fMnM1Ggf3GwRoIKWX1Z1gw2iEo1TpkjsTDdAGYUx8j39KKdX/6FbTufR6NW7Yl5S2mBhKD6o0r//i3mepcNQmc+uyk7DEGauBVkDa12XWHMRgx5XJU0ri1HY1bHzCOM9YUp6cw97/nLMfSDK3YXZ3DDrtrPqrhSRAsS9IL4JgxECHV5GAYTXMO3622pL0angXBsiRUtO8xBiKA5WCcQG3d3ZNyndeT5aVIL6cfwJRxNGRYDsYJApCrBP7Ez8nyJYhaDh/p3AjLwTilSeBEreXstfCVYmmiSrVYDsYpflMrjd8USxN6qsVyME4JIrXSBCKISrX6jYGAYDkYN6zO4Xt+UytNICmWZrRD0DXsfcaAD1gOxg10Ge3nJuWOoE5aUCmWZiDIfX1ZDsYNtL9ug8AfBXnSAhVE7cgYSD3CcjBuUHXHAS+z5dUIOoLoa9h91SMsB+MWqjucXGPulkBrkHK8LmhkORi3eF2I6ITQBIGHop3lYNwSdFFeSeApVgWOi3aWg3FLGEV5JaEKoor2nlqSsByMW0iOJoGdQRfllYQdQbQkvXadLZaDcQt1rJoEng5bDkQhCO7OtPdUSsJyMG4hOVbn8HxQM+W1iEQQ3G3/3pGE5WDcouUIo51rR6hdLCtGO0T3TBGnZ4toshhmGEvikANRRhCNiiR99IGNQYaxIC45EIcgBH1Q+sAsCVOLOOVAXIKAJWEcELcciKMGqeS9dvGFeYm3CxLNxiBTt6h5jqej6lbZEbsgWJakY17iPEvCIMJJQCckQhAoSZYkfrIgsd0YZOqGsNdWuSUxgmh+sU0Mz8t49tpi4iXMVbleia1It4NOEO2Ex8V7/UDfa/qeJ00OJDGCaM60i+cWJN7guiTbUL1BVwLG2amqRmIFAdclmYfqDVqunoRi3I5EC6I50y6+M1fEX8tSNGbSjprf+J7XDaWjJBWCQM2XLEj8aEmizRhkUgPteEibusU9v+GU1AiieXebODYvsZejSbpQ13Cc+L1JuS9Nbzx1goCjSepIW9QoJ5WCaKg2mS/ia0WgwRhkYofu7NSUw6tpqDXsSLUgUJ2ugsQRnlxMFjTplxfoS3KHygmpF0RDadeixNFFic3GIBMZdKtluptsGtMpKzIjiOZMuxhYlDjE9Um0UJ1BN+l3ex/ypJM5QTQsSjRkVQxNZgXRsCjhkHUxNJkXRENruwoS3+ZlK/6g5SF5gW8kde1U0NSNIBoq5gsS31qU+Dy3h51B7dpGgZ/lBV7MSvHtlLoTpByaR1mS6OfOlzXUkWoQGErzPIZf6loQDc2lFIGXFiW+VO/L62n5eaPAD3LAK2mfwwgCFqQCSsGKEi8UgKfqJbJQpMgDp3MCr9VbClULFqQKFFkk8NWCxP4liY6s1CxUUzQIjOcFjgrg+xwp7GFBXFCKLkB/UaKnAGxNSzpGaVMeuJgTGM4BQxwlnMOC+ITmWaTEniLwWBHYEPd8C81P5ICrOeBXQuBU1ucpwoYFCQGVmu2TwKNSYocEWotAJ72SBJq8Rh6KBAKYx3KaNCaAKSHwawGcE8AxTpUCBsD/A64FlTxHWoHIAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: unifiedpush-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: unifiedpush-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: unifiedpush-operator
+            spec:
+              containers:
+              - command:
+                - unifiedpush-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: unifiedpush-operator
+                image: quay.io/aerogear/unifiedpush-operator:v0.5.1
+                imagePullPolicy: Always
+                name: unifiedpush-operator
+                resources:
+                  limits:
+                    cpu: 60m
+                    memory: 128Mi
+                  requests:
+                    cpu: 30m
+                    memory: 64Mi
+              serviceAccountName: unifiedpush-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - push.aerogear.org
+          resources:
+          - unifiedpushservers
+          - unifiedpushservers/status
+          - unifiedpushservers/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resourceNames:
+          - unifiedpush-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+        - apiGroups:
+          - enmasse.io
+          resources:
+          - addresses
+          - addressspaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - enmasse.io
+          resources:
+          - addressspaceschemas
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - user.enmasse.io
+          resources:
+          - messagingusers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: unifiedpush-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - AeroGear
+  - Push
+  - UPS
+  - Mobile
+  links:
+  - name: AeroGear
+    url: https://aerogear.org/
+  maintainers:
+  - email: aerogear@googlegroups.com
+    name: AeroGear
+  maturity: alpha
+  provider:
+    name: AeroGear
+  replaces: unifiedpush-operator.v0.5.0
+  version: 0.5.1

--- a/deploy/olm-catalog/unifiedpush-operator/unifiedpush-operator.package.yaml
+++ b/deploy/olm-catalog/unifiedpush-operator/unifiedpush-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: unifiedpush-operator.v0.5.0
+- currentCSV: unifiedpush-operator.v0.5.1
   name: stable
 defaultChannel: stable
 packageName: unifiedpush-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: unifiedpush-operator
       containers:
         - name: unifiedpush-operator
-          image: quay.io/aerogear/unifiedpush-operator:v0.5.0
+          image: quay.io/aerogear/unifiedpush-operator:v0.5.1
           command:
           - unifiedpush-operator
           imagePullPolicy: Always

--- a/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
+++ b/pkg/controller/unifiedpushserver/unifiedpushserver_controller.go
@@ -712,110 +712,110 @@ func (r *ReconcileUnifiedPushServer) Reconcile(request reconcile.Request) (recon
 		if err != nil {
 			return r.manageError(instance, err)
 		}
-	} else if err != nil {
+	}
+	if err != nil {
 		return r.manageError(instance, err)
-	} else {
-		unifiedPushResourceRequirements := getUnifiedPushResourceRequirements(instance)
-		oauthProxyResourceRequirements := getOauthProxyResourceRequirements(instance)
+	}
 
-		containers := foundUnifiedpushDeployment.Spec.Template.Spec.Containers
-		for i := range containers {
-			if containers[i].Name == cfg.UPSContainerName {
-				if reflect.DeepEqual(containers[i].Resources, unifiedPushResourceRequirements) == false {
-					reqLogger.Info("UnifiedPush container resource requirements are different than in the UnifiedPushServer spec or the operator defaults", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "Found resource requirements", containers[i].Resources, "Spec resource requirements", unifiedPushResourceRequirements)
+	unifiedPushResourceRequirements := getUnifiedPushResourceRequirements(instance)
+	oauthProxyResourceRequirements := getOauthProxyResourceRequirements(instance)
 
-					containers[i].Resources = unifiedPushResourceRequirements
+	containers := foundUnifiedpushDeployment.Spec.Template.Spec.Containers
+	for i := range containers {
+		if containers[i].Name == cfg.UPSContainerName {
+			if reflect.DeepEqual(containers[i].Resources, unifiedPushResourceRequirements) == false {
+				reqLogger.Info("UnifiedPush container resource requirements are different than in the UnifiedPushServer spec or the operator defaults", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "Found resource requirements", containers[i].Resources, "Spec resource requirements", unifiedPushResourceRequirements)
 
-					// enqueue
-					err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
-					if err != nil {
-						reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
-						return r.manageError(instance, err)
-					}
-					return reconcile.Result{Requeue: true}, nil
+				containers[i].Resources = unifiedPushResourceRequirements
+
+				// enqueue
+				err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
+				if err != nil {
+					reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
+					return r.manageError(instance, err)
 				}
-			} else if containers[i].Name == cfg.OauthProxyContainerName {
-				if reflect.DeepEqual(containers[i].Resources, oauthProxyResourceRequirements) == false {
-					reqLogger.Info("OauthProxy container resource requirements are different than in the UnifiedPushServer spec or the operator defaults", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "Found resource requirements", containers[i].Resources, "Spec resource requirements", oauthProxyResourceRequirements)
+				return reconcile.Result{Requeue: true}, nil
+			}
+		} else if containers[i].Name == cfg.OauthProxyContainerName {
+			if reflect.DeepEqual(containers[i].Resources, oauthProxyResourceRequirements) == false {
+				reqLogger.Info("OauthProxy container resource requirements are different than in the UnifiedPushServer spec or the operator defaults", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "Found resource requirements", containers[i].Resources, "Spec resource requirements", oauthProxyResourceRequirements)
 
-					containers[i].Resources = oauthProxyResourceRequirements
+				containers[i].Resources = oauthProxyResourceRequirements
 
-					// enqueue
-					err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
-					if err != nil {
-						reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
-						return r.manageError(instance, err)
-					}
-					return reconcile.Result{Requeue: true}, nil
+				// enqueue
+				err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
+				if err != nil {
+					reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
+					return r.manageError(instance, err)
 				}
+				return reconcile.Result{Requeue: true}, nil
 			}
 		}
+	}
 
-		desiredUnifiedPushImage := constants.UPSImage
-		desiredProxyImage := constants.OauthProxyImage
+	desiredUnifiedPushImage := constants.UPSImage
+	desiredProxyImage := constants.OauthProxyImage
 
-		unifiedPushContainerSpec := findContainerSpec(foundUnifiedpushDeployment, cfg.UPSContainerName)
-		if unifiedPushContainerSpec == nil {
-			reqLogger.Info("Unable to do image reconcile: Unable to find container spec in deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "ContainerSpec", cfg.UPSContainerName)
-			return reconcile.Result{Requeue: true}, nil
-		} else if unifiedPushContainerSpec.Image != desiredUnifiedPushImage {
-			reqLogger.Info("Container spec in deployment is using a different image. Going to update it now.", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "ContainerSpec", cfg.UPSContainerName, "ExistingImage", unifiedPushContainerSpec.Image, "DesiredImage", desiredUnifiedPushImage)
+	unifiedPushContainerSpec := findContainerSpec(foundUnifiedpushDeployment, cfg.UPSContainerName)
+	if unifiedPushContainerSpec == nil {
+		reqLogger.Info("Unable to do image reconcile: Unable to find container spec in deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "ContainerSpec", cfg.UPSContainerName)
+		return reconcile.Result{Requeue: true}, nil
+	} else if unifiedPushContainerSpec.Image != desiredUnifiedPushImage {
+		reqLogger.Info("Container spec in deployment is using a different image. Going to update it now.", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "ContainerSpec", cfg.UPSContainerName, "ExistingImage", unifiedPushContainerSpec.Image, "DesiredImage", desiredUnifiedPushImage)
 
-			// update
-			updateContainerSpecImage(foundUnifiedpushDeployment, cfg.UPSContainerName, desiredUnifiedPushImage)
+		// update
+		updateContainerSpecImage(foundUnifiedpushDeployment, cfg.UPSContainerName, desiredUnifiedPushImage)
 
-			// enqueue
-			err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
-			if err != nil {
-				reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
-				return r.manageError(instance, err)
-			}
-			return reconcile.Result{Requeue: true}, nil
-		}
-
-		proxyContainerSpec := findContainerSpec(foundUnifiedpushDeployment, cfg.OauthProxyContainerName)
-		if proxyContainerSpec == nil {
-			reqLogger.Info("Unable to do image reconcile: Unable to find container spec in deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "ContainerSpec", cfg.OauthProxyContainerName)
-			return reconcile.Result{Requeue: true}, nil
-		} else if proxyContainerSpec.Image != desiredProxyImage {
-			reqLogger.Info("Container spec in deployment is using a different image. Going to update it now.", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "ContainerSpec", cfg.OauthProxyContainerName, "ExistingImage", proxyContainerSpec.Image, "DesiredImage", desiredProxyImage)
-
-			// update
-			updateContainerSpecImage(foundUnifiedpushDeployment, cfg.OauthProxyContainerName, desiredProxyImage)
-
-			// enqueue
-			err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
-			if err != nil {
-				reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
-				return r.manageError(instance, err)
-			}
-			return reconcile.Result{Requeue: true}, nil
-		}
-
-		podSpec := findPodSpec(foundUnifiedpushDeployment)
-		if podSpec == nil {
-			reqLogger.Info("Unable to do image reconcile: Unable to find pod spec in deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
-			return reconcile.Result{Requeue: true}, nil
-		} else {
-			podSpec.Affinity = instance.Spec.Affinity
-			podSpec.Tolerations = instance.Spec.Tolerations
-
-			// update
-			err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
-			if err != nil {
-				reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
-				return r.manageError(instance, err)
-			}
-			return reconcile.Result{Requeue: true}, nil
-		}
-
-		// Set ready status
-		deploymentReady, err := isDeploymentReady(foundUnifiedpushDeployment)
+		// enqueue
+		err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
 		if err != nil {
+			reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
 			return r.manageError(instance, err)
 		}
-		readyStatus = readyStatus && deploymentReady
+		return reconcile.Result{Requeue: true}, nil
 	}
+
+	proxyContainerSpec := findContainerSpec(foundUnifiedpushDeployment, cfg.OauthProxyContainerName)
+	if proxyContainerSpec == nil {
+		reqLogger.Info("Unable to do image reconcile: Unable to find container spec in deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "ContainerSpec", cfg.OauthProxyContainerName)
+		return reconcile.Result{Requeue: true}, nil
+	} else if proxyContainerSpec.Image != desiredProxyImage {
+		reqLogger.Info("Container spec in deployment is using a different image. Going to update it now.", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name, "ContainerSpec", cfg.OauthProxyContainerName, "ExistingImage", proxyContainerSpec.Image, "DesiredImage", desiredProxyImage)
+
+		// update
+		updateContainerSpecImage(foundUnifiedpushDeployment, cfg.OauthProxyContainerName, desiredProxyImage)
+
+		// enqueue
+		err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
+		if err != nil {
+			reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
+			return r.manageError(instance, err)
+		}
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	podSpec := findPodSpec(foundUnifiedpushDeployment)
+	if podSpec == nil {
+		reqLogger.Info("Unable to do image reconcile: Unable to find pod spec in deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
+		return reconcile.Result{Requeue: true}, nil
+	}
+	podSpec.Affinity = instance.Spec.Affinity
+	podSpec.Tolerations = instance.Spec.Tolerations
+
+	// update
+	err = r.client.Update(context.TODO(), foundUnifiedpushDeployment)
+	if err != nil {
+		reqLogger.Error(err, "Failed to update Deployment", "Deployment.Namespace", foundUnifiedpushDeployment.Namespace, "Deployment.Name", foundUnifiedpushDeployment.Name)
+		return r.manageError(instance, err)
+	}
+
+	// Set ready status
+	deploymentReady, err := isDeploymentReady(foundUnifiedpushDeployment)
+	if err != nil {
+		return r.manageError(instance, err)
+	}
+	readyStatus = readyStatus && deploymentReady
+
 	secondaryResources.add("Deployment", unifiedpushDeployment.Name)
 	//#endregion
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "v0.5.0"
+	Version = "v0.5.1"
 )


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-10773

## What
Alerts updated to support OpenShift 4.8

## Why
Alerts didn't support OpenShift 4.8

## How
 Change certain alerts queries.

## Verification Steps
-Login to the provided cluster.
-Ensure v0.5.1 of UPS is installed.
-Go to UPS deployment and scale down the pod to 0.
-Check that alerts are pending in Prometheus.
-Check that alerts also have the updated query.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
