### PR TITLE
v is for version, not vendetta

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.5.1"
+	Version = "v0.5.1"
 )


### PR DESCRIPTION
We thought we couldn't use v due to a limitation in the new pipeline but now it's possible to use the v in the version. As the previous v0.5.0 used the v and all the files for the manifests are generated based on having the v I am adding it back in.